### PR TITLE
[JENKINS-30206] Test demonstrating that new branch properties are invoked

### DIFF
--- a/src/test/java/org/jenkinsci/plugins/workflow/multibranch/WorkflowMultiBranchProjectTest.java
+++ b/src/test/java/org/jenkinsci/plugins/workflow/multibranch/WorkflowMultiBranchProjectTest.java
@@ -27,6 +27,8 @@ package org.jenkinsci.plugins.workflow.multibranch;
 import hudson.ExtensionList;
 import hudson.model.DescriptorVisibilityFilter;
 import hudson.model.Item;
+import hudson.model.Job;
+import hudson.model.Run;
 import hudson.model.listeners.ItemListener;
 import hudson.plugins.git.GitSCM;
 import hudson.scm.ChangeLogParser;
@@ -42,6 +44,7 @@ import jenkins.branch.BranchProperty;
 import jenkins.branch.BranchPropertyDescriptor;
 import jenkins.branch.BranchSource;
 import jenkins.branch.DefaultBranchPropertyStrategy;
+import jenkins.branch.JobDecorator;
 import jenkins.plugins.git.GitSCMSource;
 import jenkins.scm.api.SCMHead;
 import jenkins.scm.api.SCMSource;
@@ -188,6 +191,38 @@ public class WorkflowMultiBranchProjectTest {
         List<String> names = new ArrayList<>();
         @Override public void onCreated(Item item) {
             names.add(item.getFullName());
+        }
+    }
+
+    @Ignore
+    @Issue("JENKINS-30206")
+    @Test public void branchSourceUpdated() throws Exception {
+        sampleRepo.init();
+        sampleRepo.write("Jenkinsfile", "");
+        sampleRepo.git("add", ".");
+        sampleRepo.git("commit", "--all", "--message=flow");
+
+        WorkflowMultiBranchProject mp = r.jenkins.createProject(WorkflowMultiBranchProject.class, "p");
+
+        GitSCMSource source = new GitSCMSource(null, sampleRepo.toString(), "", "*", "", false);
+        mp.getSourcesList().add(new BranchSource(source, new DefaultBranchPropertyStrategy(new BranchProperty[0])));
+        scheduleAndFindBranchProject(mp, "master");
+
+        BranchSourceUpdatedBranchProperty p = new BranchSourceUpdatedBranchProperty();
+        mp.getSourcesList().clear();
+        mp.getSourcesList().add(new BranchSource(source, new DefaultBranchPropertyStrategy(new BranchProperty[] { p })));
+        scheduleAndFindBranchProject(mp, "master");
+        assertTrue("branch property not invoked", p.branchPropertyInvoked[0]);
+    }
+    public static class BranchSourceUpdatedBranchProperty extends BranchProperty {
+        final Boolean[] branchPropertyInvoked = { false };
+        @Override public <P extends Job<P, B>, B extends Run<P, B>> JobDecorator<P, B> jobDecorator(Class<P> clazz) {
+            return new JobDecorator<P, B>() {
+                @Override public P project(P project) {
+                    branchPropertyInvoked[0] = true;
+                    return super.project(project);
+                }
+            };
         }
     }
 


### PR DESCRIPTION
[JENKINS-30206](https://issues.jenkins-ci.org/browse/JENKINS-30206)

The problem as I see it is as follows: 

- Branch [is compared](https://github.com/jenkinsci/branch-api-plugin/blob/48717c40c8b0f778073a595a0087f39274d71238/src/main/java/jenkins/branch/Branch.java#L167) by source id and head
- Workflow factory [will not update Branch](https://github.com/jenkinsci/workflow-multibranch-plugin/blob/0d311cdc459539b219927ac9124054d18b986385/src/main/java/org/jenkinsci/plugins/workflow/multibranch/WorkflowBranchProjectFactory.java#L62) in Workflow job when the current one is equal to [the new one](https://github.com/jenkinsci/branch-api-plugin/blob/48717c40c8b0f778073a595a0087f39274d71238/src/main/java/jenkins/branch/MultiBranchProject.java#L259)

As you can see the branch source has changed even though source's id and branch head have not. Note that this affect not only branch properties but also, for example, checkout credentials.