### PR TITLE
Warn if jenkinsfile is encountered when searching for Jenkinsfile

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/workflow/multibranch/WorkflowMultiBranchProject.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/multibranch/WorkflowMultiBranchProject.java
@@ -31,6 +31,7 @@ import hudson.model.TaskListener;
 import hudson.model.TopLevelItem;
 import hudson.scm.SCMDescriptor;
 import java.io.IOException;
+import java.util.Locale;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import jenkins.branch.BranchProjectFactory;
@@ -50,9 +51,17 @@ public class WorkflowMultiBranchProject extends MultiBranchProject<WorkflowJob,W
     private static final Logger LOGGER = Logger.getLogger(WorkflowMultiBranchProject.class.getName());
 
     static final String SCRIPT = "Jenkinsfile";
+    private static final String SCRIPT_LOWERCASE = SCRIPT.toLowerCase(Locale.ENGLISH);
     static final SCMSourceCriteria CRITERIA = new SCMSourceCriteria() {
         @Override public boolean isHead(SCMSourceCriteria.Probe probe, TaskListener listener) throws IOException {
-            return probe.exists(SCRIPT);
+            if (probe.exists(SCRIPT)) {
+                return true;
+            } else {
+                if (probe.exists(SCRIPT_LOWERCASE)) {
+                    listener.getLogger().println("Found " + SCRIPT_LOWERCASE + " rather than " + SCRIPT + ", skipping");
+                }
+                return false;
+            }
         }
     };
 


### PR DESCRIPTION
@recena claimed to have had some trouble diagnosing this, so make it more apparent.

Actually accepting a branch with `jenkinsfile` is more complicated, due to usage from `SCMVar`, and this does not try—just alerts the user to the mistake.

The downside is more time (and perhaps network traffic) spent rejecting non-multibranch-ready branches and repositories. And in the case of `github-branch-source`, extra noise as the source prints messages about `jenkinsfile` not existing, which is probably more confusing than helpful because it implies that `jenkinsfile` _would_ be accepted. So we need some refined solution TBD.

@reviewbybees