### PR TITLE
Adding a keepBuilds standalone step.

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/workflow/multibranch/JobPropertyStep.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/multibranch/JobPropertyStep.java
@@ -91,7 +91,7 @@ public class JobPropertyStep extends AbstractStepImpl {
             BulkChange bc = new BulkChange(job);
             try {
                 for (JobProperty prop : job.getAllProperties()) {
-                    if (prop instanceof BranchJobProperty) {
+                    if (prop instanceof BranchJobProperty || !isConfiguredProperty(prop)) {
                         // TODO do we need to define an API for other properties which should not be removed?
                         continue;
                     }
@@ -107,9 +107,27 @@ public class JobPropertyStep extends AbstractStepImpl {
             return null;
         }
 
+        /**
+         * Checks to see if the existing {@link JobProperty} is of a type defined in the step. We will only remove
+         * properties that are defined in the step.
+         *
+         * @param existingProperty An existing property on the job.
+         * @return True if the existing property is of a type defined in the step, false otherwise
+         */
+        private boolean isConfiguredProperty(JobProperty existingProperty) {
+            for (JobProperty prop : step.properties) {
+                if (prop.getClass().isInstance(existingProperty)) {
+                    return true;
+                }
+            }
+
+            return false;
+        }
+
         private static final long serialVersionUID = 1L;
 
     }
+
 
     @Extension public static class DescriptorImpl extends AbstractStepDescriptorImpl {
 

--- a/src/main/java/org/jenkinsci/plugins/workflow/multibranch/KeepBuildsStep.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/multibranch/KeepBuildsStep.java
@@ -1,0 +1,152 @@
+/*
+ * The MIT License
+ *
+ * Copyright 2015 CloudBees, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package org.jenkinsci.plugins.workflow.multibranch;
+
+import hudson.BulkChange;
+import hudson.Extension;
+import hudson.model.Job;
+import hudson.model.JobProperty;
+import hudson.model.Run;
+import hudson.tasks.LogRotator;
+import jenkins.model.BuildDiscarderProperty;
+import org.jenkinsci.plugins.workflow.steps.AbstractStepDescriptorImpl;
+import org.jenkinsci.plugins.workflow.steps.AbstractStepImpl;
+import org.jenkinsci.plugins.workflow.steps.AbstractSynchronousStepExecution;
+import org.jenkinsci.plugins.workflow.steps.StepContextParameter;
+import org.kohsuke.stapler.DataBoundConstructor;
+import org.kohsuke.stapler.DataBoundSetter;
+
+import javax.inject.Inject;
+
+
+/**
+ * Convenience step for {@link BuildDiscarderProperty}.
+ */
+public class KeepBuildsStep extends AbstractStepImpl {
+
+    /**
+     * If not -1 or null, history is only kept up to this days.
+     */
+    public Integer daysToKeep;
+
+    /**
+     * If not -1 or null, only this number of build logs are kept.
+     */
+    public Integer numToKeep;
+
+    /**
+     * If not -1 or null, artifacts are only kept up to this days.
+     */
+    public Integer artifactDaysToKeep;
+
+    /**
+     * If not -1 or null, only this number of builds have their artifacts kept.
+     */
+    public Integer artifactNumToKeep;
+
+    @DataBoundConstructor public KeepBuildsStep() {
+
+    }
+
+    // Setters are here so that Snippet Generator works properly.
+    @DataBoundSetter public void setDaysToKeep(Integer daysToKeep) {
+        this.daysToKeep = daysToKeep;
+    }
+
+    @DataBoundSetter public void setNumToKeep(Integer numToKeep) {
+        this.numToKeep = numToKeep;
+    }
+
+    @DataBoundSetter public void setArtifactDaysToKeep(Integer artifactDaysToKeep) {
+        this.artifactDaysToKeep = artifactDaysToKeep;
+    }
+
+    @DataBoundSetter public void setArtifactNumToKeep(Integer artifactNumToKeep) {
+        this.artifactNumToKeep = artifactNumToKeep;
+    }
+
+    // Getters are here because NPEs were hit when just using the fields.
+    public Integer getDaysToKeepValue() {
+        return daysToKeep != null ? daysToKeep : -1;
+    }
+
+    public Integer getNumToKeepValue() {
+        return numToKeep != null ? numToKeep : -1;
+    }
+
+    public Integer getArtifactDaysToKeepValue() {
+        return artifactDaysToKeep != null ? artifactDaysToKeep : -1;
+    }
+
+    public Integer getArtifactNumToKeepValue() {
+        return artifactNumToKeep != null ? artifactNumToKeep : -1;
+    }
+
+    public static class Execution extends AbstractSynchronousStepExecution<Void> {
+
+        @Inject transient KeepBuildsStep step;
+        @StepContextParameter transient Run<?,?> build;
+
+        @SuppressWarnings("unchecked") // untypable
+        @Override protected Void run() throws Exception {
+            Job<?,?> job = build.getParent();
+
+            BulkChange bc = new BulkChange(job);
+            try {
+                for (JobProperty prop : job.getAllProperties()) {
+                    if (prop instanceof BuildDiscarderProperty) {
+                        job.removeProperty(prop);
+                    }
+                }
+                job.addProperty(new BuildDiscarderProperty(new LogRotator(step.getDaysToKeepValue(),
+                        step.getNumToKeepValue(),
+                        step.getArtifactDaysToKeepValue(),
+                        step.getArtifactNumToKeepValue())));
+                bc.commit();
+            } finally {
+                bc.abort();
+            }
+            return null;
+        }
+
+        private static final long serialVersionUID = 1L;
+
+    }
+
+    @Extension public static class DescriptorImpl extends AbstractStepDescriptorImpl {
+
+        public DescriptorImpl() {
+            super(Execution.class);
+        }
+
+        @Override public String getFunctionName() {
+            return "keepBuilds";
+        }
+
+        @Override public String getDisplayName() {
+            return "Set policy for keeping old builds";
+        }
+    }
+}

--- a/src/main/resources/org/jenkinsci/plugins/workflow/multibranch/KeepBuildsStep/config.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/workflow/multibranch/KeepBuildsStep/config.jelly
@@ -1,0 +1,46 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+The MIT License
+
+Copyright 2016 CloudBees, Inc.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+-->
+
+<?jelly escape-by-default='true'?>
+<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
+    <f:entry title="${%Days to keep builds}"
+             description="${%if not empty, build records are only kept up to this number of days}" field="daysToKeep">
+        <f:number clazz="positive-number" min="1" step="1" />
+    </f:entry>
+    <f:entry title="${%Max # of builds to keep}"
+             description="${%if not empty, only up to this number of build records are kept}" field="numToKeep">
+        <f:number clazz="positive-number" min="1" step="1" />
+    </f:entry>
+    <f:advanced>
+        <f:entry title="${%Days to keep artifacts}"
+                 description="${%if not empty, artifacts from builds older than this number of days will be deleted, but the logs, history, reports, etc for the build will be kept}" field="artifactDaysToKeep">
+            <f:number clazz="positive-number" min="1" step="1" />
+        </f:entry>
+        <f:entry title="${%Max # of builds to keep with artifacts}"
+                 description="${%if not empty, only up to this number of builds have their artifacts retained}" field="artifactNumToKeep">
+            <f:number clazz="positive-number" min="1" step="1" />
+        </f:entry>
+    </f:advanced>
+</j:jelly>

--- a/src/main/resources/org/jenkinsci/plugins/workflow/multibranch/KeepBuildsStep/help.html
+++ b/src/main/resources/org/jenkinsci/plugins/workflow/multibranch/KeepBuildsStep/help.html
@@ -1,0 +1,4 @@
+<div>
+    Configures the policy for keeping old builds.
+    Mainly useful from multibranch Pipelines, so that <code>Jenkinsfile</code> itself can encode what would otherwise be static job configuration.
+</div>

--- a/src/test/java/org/jenkinsci/plugins/workflow/multibranch/JobPropertyStepTest.java
+++ b/src/test/java/org/jenkinsci/plugins/workflow/multibranch/JobPropertyStepTest.java
@@ -159,6 +159,49 @@ public class JobPropertyStepTest {
         assertNull(b3.getPreviousBuild());
     }
 
+    @SuppressWarnings("deprecation") // RunList.size
+    @Test public void doRemoveConfiguredProperties() throws Exception {
+        sampleRepo.init();
+        sampleRepo.write("Jenkinsfile", "keepBuilds(numToKeep: 2)\n"
+                + "properties([[$class: 'BuildDiscarderProperty', strategy: [$class: 'LogRotator', numToKeepStr: '1']]])");
+        sampleRepo.git("add", "Jenkinsfile");
+        sampleRepo.git("commit", "--all", "--message=flow");
+        WorkflowMultiBranchProject mp = r.jenkins.createProject(WorkflowMultiBranchProject.class, "p");
+        mp.getSourcesList().add(new BranchSource(new GitSCMSource(null, sampleRepo.toString(), "", "*", "", false), new DefaultBranchPropertyStrategy(new BranchProperty[0])));
+        WorkflowJob p = scheduleAndFindBranchProject(mp, "master");
+        assertEquals(1, mp.getItems().size());
+        r.waitUntilNoActivity(); // #1 built automatically
+        assertEquals(1, p.getBuilds().size());
+        r.assertBuildStatusSuccess(p.scheduleBuild2(0)); // #2
+        assertEquals(1, p.getBuilds().size());
+        r.assertBuildStatusSuccess(p.scheduleBuild2(0)); // #3
+        assertEquals(1, p.getBuilds().size());
+        WorkflowRun b3 = p.getLastBuild();
+        assertEquals(3, b3.getNumber());
+        assertNull(b3.getPreviousBuild());
+    }
 
 
+    @SuppressWarnings("deprecation") // RunList.size
+    @Test public void overrideConfiguredProperty() throws Exception {
+        sampleRepo.init();
+        sampleRepo.write("Jenkinsfile", "properties([[$class: 'BuildDiscarderProperty', strategy: "
+                + "[$class: 'LogRotator', numToKeepStr: '2']]])\n"
+                + "keepBuilds(numToKeep: 1)");
+        sampleRepo.git("add", "Jenkinsfile");
+        sampleRepo.git("commit", "--all", "--message=flow");
+        WorkflowMultiBranchProject mp = r.jenkins.createProject(WorkflowMultiBranchProject.class, "p");
+        mp.getSourcesList().add(new BranchSource(new GitSCMSource(null, sampleRepo.toString(), "", "*", "", false), new DefaultBranchPropertyStrategy(new BranchProperty[0])));
+        WorkflowJob p = scheduleAndFindBranchProject(mp, "master");
+        assertEquals(1, mp.getItems().size());
+        r.waitUntilNoActivity(); // #1 built automatically
+        assertEquals(1, p.getBuilds().size());
+        r.assertBuildStatusSuccess(p.scheduleBuild2(0)); // #2
+        assertEquals(1, p.getBuilds().size());
+        r.assertBuildStatusSuccess(p.scheduleBuild2(0)); // #3
+        assertEquals(1, p.getBuilds().size());
+        WorkflowRun b3 = p.getLastBuild();
+        assertEquals(3, b3.getNumber());
+        assertNull(b3.getPreviousBuild());
+    }
 }

--- a/src/test/java/org/jenkinsci/plugins/workflow/multibranch/JobPropertyStepTest.java
+++ b/src/test/java/org/jenkinsci/plugins/workflow/multibranch/JobPropertyStepTest.java
@@ -136,4 +136,29 @@ public class JobPropertyStepTest {
         assertNull(b3.getPreviousBuild());
     }
 
+    @SuppressWarnings("deprecation") // RunList.size
+    @Test public void doNotRemoveUnconfiguredProperties() throws Exception {
+        sampleRepo.init();
+        sampleRepo.write("Jenkinsfile", "keepBuilds(numToKeep: 1)\n"
+                + "properties([[$class: 'ParametersDefinitionProperty', parameterDefinitions: [[$class: "
+                + "'BooleanParameterDefinition', defaultValue: false, description: '', name: 'FOO']]]])");
+        sampleRepo.git("add", "Jenkinsfile");
+        sampleRepo.git("commit", "--all", "--message=flow");
+        WorkflowMultiBranchProject mp = r.jenkins.createProject(WorkflowMultiBranchProject.class, "p");
+        mp.getSourcesList().add(new BranchSource(new GitSCMSource(null, sampleRepo.toString(), "", "*", "", false), new DefaultBranchPropertyStrategy(new BranchProperty[0])));
+        WorkflowJob p = scheduleAndFindBranchProject(mp, "master");
+        assertEquals(1, mp.getItems().size());
+        r.waitUntilNoActivity(); // #1 built automatically
+        assertEquals(1, p.getBuilds().size());
+        r.assertBuildStatusSuccess(p.scheduleBuild2(0)); // #2
+        assertEquals(1, p.getBuilds().size());
+        r.assertBuildStatusSuccess(p.scheduleBuild2(0)); // #3
+        assertEquals(1, p.getBuilds().size());
+        WorkflowRun b3 = p.getLastBuild();
+        assertEquals(3, b3.getNumber());
+        assertNull(b3.getPreviousBuild());
+    }
+
+
+
 }

--- a/src/test/java/org/jenkinsci/plugins/workflow/multibranch/KeepBuildsStepTest.java
+++ b/src/test/java/org/jenkinsci/plugins/workflow/multibranch/KeepBuildsStepTest.java
@@ -1,0 +1,85 @@
+/*
+ * The MIT License
+ *
+ * Copyright 2015 CloudBees, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package org.jenkinsci.plugins.workflow.multibranch;
+
+import jenkins.branch.BranchProperty;
+import jenkins.branch.BranchSource;
+import jenkins.branch.DefaultBranchPropertyStrategy;
+import jenkins.plugins.git.GitSCMSource;
+import org.jenkinsci.plugins.workflow.job.WorkflowJob;
+import org.jenkinsci.plugins.workflow.job.WorkflowRun;
+import org.jenkinsci.plugins.workflow.steps.StepConfigTester;
+import org.jenkinsci.plugins.workflow.steps.scm.GitSampleRepoRule;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.jvnet.hudson.test.BuildWatcher;
+import org.jvnet.hudson.test.JenkinsRule;
+
+import static org.jenkinsci.plugins.workflow.multibranch.WorkflowMultiBranchProjectTest.scheduleAndFindBranchProject;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+
+public class KeepBuildsStepTest {
+
+    @ClassRule public static BuildWatcher buildWatcher = new BuildWatcher();
+    @Rule public JenkinsRule r = new JenkinsRule();
+    @Rule public GitSampleRepoRule sampleRepo = new GitSampleRepoRule();
+
+
+    @SuppressWarnings("rawtypes")
+    @Test public void configRoundTrip() throws Exception {
+        StepConfigTester tester = new StepConfigTester(r);
+        KeepBuildsStep step = new KeepBuildsStep();
+        step.setDaysToKeep(1);
+        step.setNumToKeep(2);
+        //step.artifactDaysToKeep = -1;
+        step.setArtifactNumToKeep(3);
+        KeepBuildsStep resultStep = tester.configRoundTrip(step);
+        r.assertEqualDataBoundBeans(step, resultStep);
+    }
+
+    @SuppressWarnings("deprecation") // RunList.size
+    @Test public void useBuildDiscarder() throws Exception {
+        sampleRepo.init();
+        sampleRepo.write("Jenkinsfile", "keepBuilds(numToKeep: 1)");
+        sampleRepo.git("add", "Jenkinsfile");
+        sampleRepo.git("commit", "--all", "--message=flow");
+        WorkflowMultiBranchProject mp = r.jenkins.createProject(WorkflowMultiBranchProject.class, "p");
+        mp.getSourcesList().add(new BranchSource(new GitSCMSource(null, sampleRepo.toString(), "", "*", "", false), new DefaultBranchPropertyStrategy(new BranchProperty[0])));
+        WorkflowJob p = scheduleAndFindBranchProject(mp, "master");
+        assertEquals(1, mp.getItems().size());
+        r.waitUntilNoActivity(); // #1 built automatically
+        assertEquals(1, p.getBuilds().size());
+        r.assertBuildStatusSuccess(p.scheduleBuild2(0)); // #2
+        assertEquals(1, p.getBuilds().size());
+        r.assertBuildStatusSuccess(p.scheduleBuild2(0)); // #3
+        assertEquals(1, p.getBuilds().size());
+        WorkflowRun b3 = p.getLastBuild();
+        assertEquals(3, b3.getNumber());
+        assertNull(b3.getPreviousBuild());
+    }
+
+}


### PR DESCRIPTION
Log rotation is a common enough need that it made sense to have a separate step for it. I'm open to a different name if "keepBuilds" isn't ideal.

I tried to include the config.jelly for LogRotator directly, but the field names threw that off. Other hoops had to be jumped through for the Snippet Generator to work right and for null fields to be handled correctly in instantiating the LogRotator.

cc @reviewbybees @jglick 