### PR TITLE
Demonstrate that changelogs are computed for noninitial builds of Git and Subversion branch projects

### DIFF
--- a/src/test/java/org/jenkinsci/plugins/workflow/multibranch/SCMBinderTest.java
+++ b/src/test/java/org/jenkinsci/plugins/workflow/multibranch/SCMBinderTest.java
@@ -31,12 +31,16 @@ import hudson.model.TaskListener;
 import hudson.plugins.git.util.BuildData;
 import hudson.plugins.mercurial.MercurialInstallation;
 import hudson.plugins.mercurial.MercurialSCMSource;
+import hudson.scm.ChangeLogSet;
 import hudson.tools.ToolProperty;
 import java.io.File;
 import java.io.IOException;
 import java.util.Collections;
 import java.util.HashSet;
+import java.util.Iterator;
+import java.util.List;
 import java.util.Set;
+import java.util.TreeSet;
 import jenkins.branch.BranchProperty;
 import jenkins.branch.BranchSource;
 import jenkins.branch.DefaultBranchPropertyStrategy;
@@ -100,6 +104,17 @@ public class SCMBinderTest {
         r.assertLogContains("SUBSEQUENT CONTENT", b2);
         assertRevisionAction(b2);
         WorkflowMultiBranchProjectTest.showIndexing(mp);
+        List<ChangeLogSet<? extends ChangeLogSet.Entry>> changeSets = b2.getChangeSets();
+        assertEquals(1, changeSets.size());
+        ChangeLogSet<? extends ChangeLogSet.Entry> changeSet = changeSets.get(0);
+        assertEquals(b2, changeSet.getRun());
+        assertEquals("git", changeSet.getKind());
+        Iterator<? extends ChangeLogSet.Entry> iterator = changeSet.iterator();
+        assertTrue(iterator.hasNext());
+        ChangeLogSet.Entry entry = iterator.next();
+        assertEquals("tweaked", entry.getMsg());
+        assertEquals("[Jenkinsfile, file]", new TreeSet<>(entry.getAffectedPaths()).toString());
+        assertFalse(iterator.hasNext());
     }
 
     public static void assertRevisionAction(WorkflowRun build) {
@@ -139,6 +154,19 @@ public class SCMBinderTest {
         assertEquals(2, b2.getNumber());
         r.assertLogContains("initial content", r.waitForCompletion(b1));
         r.assertLogContains("SUBSEQUENT CONTENT", b2);
+        List<ChangeLogSet<? extends ChangeLogSet.Entry>> changeSets = b2.getChangeSets();
+        /* TODO JENKINS-29326 analogue: currently 2 (they are the same):
+        assertEquals(1, changeSets.size());
+        */
+        ChangeLogSet<? extends ChangeLogSet.Entry> changeSet = changeSets.get(0);
+        assertEquals(b2, changeSet.getRun());
+        assertEquals("svn", changeSet.getKind());
+        Iterator<? extends ChangeLogSet.Entry> iterator = changeSet.iterator();
+        assertTrue(iterator.hasNext());
+        ChangeLogSet.Entry entry = iterator.next();
+        assertEquals("tweaked", entry.getMsg());
+        assertEquals("[/prj/trunk/Jenkinsfile, /prj/trunk/file]", new TreeSet<>(entry.getAffectedPaths()).toString());
+        assertFalse(iterator.hasNext());
     }
 
     @Test public void exactRevisionMercurial() throws Exception {


### PR DESCRIPTION
Note that there is a trivial merge conflict with #17. The corresponding case does _not_ currently pass for Mercurial; under investigation.

@reviewbybees