### PR TITLE
JENKINS-34005 - update tests for PipelineTriggersJobProperty

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -69,12 +69,12 @@ THE SOFTWARE.
         <dependency>
             <groupId>${project.groupId}</groupId>
             <artifactId>workflow-job</artifactId>
-            <version>2.4-SNAPSHOT</version>
+            <version>2.4</version>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins.workflow</groupId>
             <artifactId>workflow-cps</artifactId>
-            <version>2.10-SNAPSHOT</version>
+            <version>2.10</version>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
@@ -104,7 +104,7 @@ THE SOFTWARE.
         <dependency>
             <groupId>${project.groupId}</groupId>
             <artifactId>workflow-basic-steps</artifactId>
-            <version>2.0</version>
+            <version>2.1</version>
             <scope>test</scope>
         </dependency>
         <dependency>
@@ -122,7 +122,7 @@ THE SOFTWARE.
         <dependency>
             <groupId>${project.groupId}</groupId>
             <artifactId>workflow-step-api</artifactId>
-            <version>2.2</version>
+            <version>2.3</version>
             <classifier>tests</classifier>
             <scope>test</scope>
         </dependency>
@@ -136,7 +136,7 @@ THE SOFTWARE.
         <dependency>
             <groupId>org.jenkins-ci.plugins.workflow</groupId>
             <artifactId>workflow-cps</artifactId>
-            <version>2.10-SNAPSHOT</version>
+            <version>2.10</version>
             <classifier>tests</classifier>
             <scope>test</scope>
         </dependency>
@@ -188,7 +188,7 @@ THE SOFTWARE.
         <dependency>
             <groupId>${project.groupId}</groupId>
             <artifactId>workflow-job</artifactId>
-            <version>2.4-SNAPSHOT</version>
+            <version>2.4</version>
             <classifier>tests</classifier>
             <scope>test</scope>
         </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -179,6 +179,13 @@ THE SOFTWARE.
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>${project.groupId}</groupId>
+            <artifactId>workflow-job</artifactId>
+            <version>2.4-SNAPSHOT</version>
+            <classifier>tests</classifier>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>org.jenkins-ci.modules</groupId>
             <artifactId>sshd</artifactId>
             <version>1.6</version>

--- a/src/test/java/org/jenkinsci/plugins/workflow/multibranch/JobPropertyStepTest.java
+++ b/src/test/java/org/jenkinsci/plugins/workflow/multibranch/JobPropertyStepTest.java
@@ -83,8 +83,7 @@ public class JobPropertyStepTest {
         StringParameterDefinition.DescriptorImpl.class.isAnnotationPresent(Symbol.class) && // "string"
         BuildDiscarderProperty.DescriptorImpl.class.isAnnotationPresent(Symbol.class) && // "buildDiscarder"
         LogRotator.LRDescriptor.class.isAnnotationPresent(Symbol.class) && // "logRotator"
-        TimerTrigger.DescriptorImpl.class.isAnnotationPresent(Symbol.class) && // "disableConcurrentBuilds"
-        PipelineTriggersJobProperty.DescriptorImpl.class.isAnnotationPresent(Symbol.class); // "pipelineTriggers"
+        TimerTrigger.DescriptorImpl.class.isAnnotationPresent(Symbol.class); // "cron"
 
     @SuppressWarnings("rawtypes")
     @Test public void configRoundTripParameters() throws Exception {

--- a/src/test/java/org/jenkinsci/plugins/workflow/multibranch/JobPropertyStepTest.java
+++ b/src/test/java/org/jenkinsci/plugins/workflow/multibranch/JobPropertyStepTest.java
@@ -66,11 +66,12 @@ public class JobPropertyStepTest {
     @SuppressWarnings("rawtypes")
     @Test public void configRoundTripParameters() throws Exception {
         StepConfigTester tester = new StepConfigTester(r);
-        assertEquals(Collections.emptyList(), tester.configRoundTrip(new JobPropertyStep(Collections.<JobProperty>emptyList())).getProperties());
+        // PipelineTriggersJobProperty is now always going to be present, even if empty.
+        assertEquals(1, tester.configRoundTrip(new JobPropertyStep(Collections.<JobProperty>emptyList())).getProperties().size());
         List<JobProperty> properties = tester.configRoundTrip(new JobPropertyStep(Collections.<JobProperty>singletonList(new ParametersDefinitionProperty(new BooleanParameterDefinition("flag", true, null))))).getProperties();
-        assertEquals(1, properties.size());
-        assertEquals(ParametersDefinitionProperty.class, properties.get(0).getClass());
-        ParametersDefinitionProperty pdp = (ParametersDefinitionProperty) properties.get(0);
+        assertEquals(2, properties.size());
+        ParametersDefinitionProperty pdp = getPropertyFromList(ParametersDefinitionProperty.class, properties);
+        assertNotNull(pdp);
         assertEquals(1, pdp.getParameterDefinitions().size());
         assertEquals(BooleanParameterDefinition.class, pdp.getParameterDefinitions().get(0).getClass());
         BooleanParameterDefinition bpd = (BooleanParameterDefinition) pdp.getParameterDefinitions().get(0);
@@ -82,11 +83,12 @@ public class JobPropertyStepTest {
     @SuppressWarnings("rawtypes")
     @Test public void configRoundTripBuildDiscarder() throws Exception {
         StepConfigTester tester = new StepConfigTester(r);
-        assertEquals(Collections.emptyList(), tester.configRoundTrip(new JobPropertyStep(Collections.<JobProperty>emptyList())).getProperties());
+        // PipelineTriggersJobProperty is now always going to be present, even if empty.
+        assertEquals(1, tester.configRoundTrip(new JobPropertyStep(Collections.<JobProperty>emptyList())).getProperties().size());
         List<JobProperty> properties = tester.configRoundTrip(new JobPropertyStep(Collections.<JobProperty>singletonList(new BuildDiscarderProperty(new LogRotator(1, 2, -1, 3))))).getProperties();
-        assertEquals(1, properties.size());
-        assertEquals(BuildDiscarderProperty.class, properties.get(0).getClass());
-        BuildDiscarderProperty bdp = (BuildDiscarderProperty) properties.get(0);
+        assertEquals(2, properties.size());
+        BuildDiscarderProperty bdp = getPropertyFromList(BuildDiscarderProperty.class, properties);
+        assertNotNull(bdp);
         BuildDiscarder strategy = bdp.getStrategy();
         assertNotNull(strategy);
         assertEquals(LogRotator.class, strategy.getClass());
@@ -185,4 +187,13 @@ public class JobPropertyStepTest {
         r.assertBuildStatusSuccess(r.waitForCompletion(b4));
     }
 
+    private <T extends JobProperty> T getPropertyFromList(Class<T> clazz, List<JobProperty> properties) {
+        for (JobProperty p : properties) {
+            if (clazz.isInstance(p)) {
+                return clazz.cast(p);
+            }
+        }
+
+        return null;
+    }
 }

--- a/src/test/java/org/jenkinsci/plugins/workflow/multibranch/JobPropertyStepTest.java
+++ b/src/test/java/org/jenkinsci/plugins/workflow/multibranch/JobPropertyStepTest.java
@@ -53,6 +53,7 @@ import org.jenkinsci.plugins.workflow.cps.CpsFlowDefinition;
 import org.jenkinsci.plugins.workflow.job.WorkflowJob;
 import org.jenkinsci.plugins.workflow.job.WorkflowRun;
 import org.jenkinsci.plugins.workflow.job.properties.PipelineTriggersJobProperty;
+import org.jenkinsci.plugins.workflow.properties.MockTrigger;
 import org.jenkinsci.plugins.workflow.steps.StepConfigTester;
 import static org.junit.Assert.*;
 
@@ -236,7 +237,7 @@ public class JobPropertyStepTest {
 
         assertTrue(mockTrigger.isStarted);
 
-        assertEquals("[false]", mockTrigger.calls.toString());
+        assertEquals("[null, false]", MockTrigger.startsAndStops.toString());
 
         // Now run a properties step with a different property and verify that we still have a
         // PipelineTriggersJobProperty, but with no triggers in it.
@@ -249,6 +250,7 @@ public class JobPropertyStepTest {
 
         assertTrue(p.getTriggers().isEmpty());
 
+        assertEquals("[null, false, null]", MockTrigger.startsAndStops.toString());
     }
 
     private <T extends Trigger> T getTriggerFromList(Class<T> clazz, List<Trigger<?>> triggers) {
@@ -269,39 +271,5 @@ public class JobPropertyStepTest {
         }
 
         return null;
-    }
-
-    public static class MockTrigger extends Trigger<Item> {
-
-        public transient List<Boolean> calls = new ArrayList<Boolean>();
-        public transient boolean isStarted = false;
-
-        @DataBoundConstructor
-        public MockTrigger() {}
-
-        @Override public void start(Item project, boolean newInstance) {
-            super.start(project, newInstance);
-            calls.add(newInstance);
-            isStarted = true;
-        }
-
-        @Override public void stop() {
-            super.stop();
-            isStarted = false;
-        }
-
-        @Override protected Object readResolve() throws ObjectStreamException {
-            calls = new ArrayList<Boolean>();
-            return super.readResolve();
-        }
-
-        @TestExtension
-        public static class DescriptorImpl extends TriggerDescriptor {
-
-            @Override public boolean isApplicable(Item item) {
-                return true;
-            }
-
-        }
     }
 }


### PR DESCRIPTION
[JENKINS-34005](https://issues.jenkins-ci.org/browse/JENKINS-34005)

Depends on https://github.com/jenkinsci/workflow-job-plugin/pull/9

* Updates existing tests to deal with the fact that there should always be a `PipelineTriggersJobProperty` on a `WorkflowJob`, even if it has no triggers in it.
* Added a new test specifically for `PipelineTriggersJobProperty`.

cc @reviewbybees esp @jglick 