### PR TITLE
[JENKINS-37731] Tests for proper handling of SCMTrigger in step.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -74,7 +74,7 @@ THE SOFTWARE.
         <dependency>
             <groupId>org.jenkins-ci.plugins.workflow</groupId>
             <artifactId>workflow-cps</artifactId>
-            <version>2.13</version>
+            <version>2.14-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
@@ -100,11 +100,6 @@ THE SOFTWARE.
             <groupId>${project.groupId}</groupId>
             <artifactId>workflow-scm-step</artifactId>
             <version>2.2</version>
-        </dependency>
-        <dependency>
-            <groupId>org.jenkins-ci.plugins</groupId>
-            <artifactId>structs</artifactId>
-            <version>1.5</version>
         </dependency>
         <dependency>
             <groupId>${project.groupId}</groupId>
@@ -141,7 +136,7 @@ THE SOFTWARE.
         <dependency>
             <groupId>org.jenkins-ci.plugins.workflow</groupId>
             <artifactId>workflow-cps</artifactId>
-            <version>2.13</version>
+            <version>2.14-SNAPSHOT</version>
             <classifier>tests</classifier>
             <scope>test</scope>
         </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -74,7 +74,7 @@ THE SOFTWARE.
         <dependency>
             <groupId>org.jenkins-ci.plugins.workflow</groupId>
             <artifactId>workflow-cps</artifactId>
-            <version>2.10</version>
+            <version>2.14-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
@@ -136,7 +136,7 @@ THE SOFTWARE.
         <dependency>
             <groupId>org.jenkins-ci.plugins.workflow</groupId>
             <artifactId>workflow-cps</artifactId>
-            <version>2.10</version>
+            <version>2.14-SNAPSHOT</version>
             <classifier>tests</classifier>
             <scope>test</scope>
         </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -74,7 +74,7 @@ THE SOFTWARE.
         <dependency>
             <groupId>org.jenkins-ci.plugins.workflow</groupId>
             <artifactId>workflow-cps</artifactId>
-            <version>2.14-SNAPSHOT</version>
+            <version>2.13</version>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
@@ -100,6 +100,11 @@ THE SOFTWARE.
             <groupId>${project.groupId}</groupId>
             <artifactId>workflow-scm-step</artifactId>
             <version>2.2</version>
+        </dependency>
+        <dependency>
+            <groupId>org.jenkins-ci.plugins</groupId>
+            <artifactId>structs</artifactId>
+            <version>1.5</version>
         </dependency>
         <dependency>
             <groupId>${project.groupId}</groupId>
@@ -136,7 +141,7 @@ THE SOFTWARE.
         <dependency>
             <groupId>org.jenkins-ci.plugins.workflow</groupId>
             <artifactId>workflow-cps</artifactId>
-            <version>2.14-SNAPSHOT</version>
+            <version>2.13</version>
             <classifier>tests</classifier>
             <scope>test</scope>
         </dependency>

--- a/src/test/java/org/jenkinsci/plugins/workflow/multibranch/JobPropertyStepTest.java
+++ b/src/test/java/org/jenkinsci/plugins/workflow/multibranch/JobPropertyStepTest.java
@@ -338,12 +338,10 @@ public class JobPropertyStepTest {
 
         // Now add a trigger.
         // Looking for core versions 2.21 and later for the proper pollScm symbol, rather than the broken scm symbol.
-        if (SCMTrigger.DescriptorImpl.class.isAnnotationPresent(Symbol.class)
-                && SymbolLookup.getSymbolValue(SCMTrigger.DescriptorImpl.class).iterator().next().equals("pollScm")) {
-
+        if (SymbolLookup.getSymbolValue(SCMTrigger.class).contains("pollSCM")) {
             p.setDefinition(new CpsFlowDefinition(
                     "properties([pipelineTriggers([\n"
-                            + "  pollScm(scmpoll_spec: '@daily', ignorePostCommitHooks: true), [$class: 'MockTrigger']])])\n"
+                            + "  pollSCM(scmpoll_spec: '@daily', ignorePostCommitHooks: true), [$class: 'MockTrigger']])])\n"
                             + "echo 'foo'", true));
         } else {
             p.setDefinition(new CpsFlowDefinition(
@@ -530,10 +528,9 @@ public class JobPropertyStepTest {
                 "  '$class': 'org.jenkinsci.plugins.workflow.multibranch.JobPropertyStep'}";
 
         // Looking for core versions 2.21 and later for the proper pollScm symbol, rather than the broken scm symbol.
-        if (SCMTrigger.DescriptorImpl.class.isAnnotationPresent(Symbol.class)
-                && SymbolLookup.getSymbolValue(SCMTrigger.DescriptorImpl.class).iterator().next().equals("pollScm")) {
-            new SnippetizerTester(r).assertGenerateSnippet(snippetJson, "properties([pipelineTriggers([pollScm('@daily')])])", null);
-            new SnippetizerTester(r).assertRoundTrip(new JobPropertyStep(properties), "properties([pipelineTriggers([pollScm('@daily')])])");
+        if (SymbolLookup.getSymbolValue(SCMTrigger.class).contains("pollSCM")) {
+            new SnippetizerTester(r).assertGenerateSnippet(snippetJson, "properties([pipelineTriggers([pollSCM('@daily')])])", null);
+            new SnippetizerTester(r).assertRoundTrip(new JobPropertyStep(properties), "properties([pipelineTriggers([pollSCM('@daily')])])");
         } else {
             /* Snippet generator won't work with SCMTrigger pre-core-2.21, due to lack of a getter for scmpoll_spec.
             new SnippetizerTester(r).assertGenerateSnippet(snippetJson, "properties([pipelineTriggers([[$class: 'SCMTrigger', scmpoll_spec: '@daily']])])", null);


### PR DESCRIPTION
[JENKINS-37731](https://issues.jenkins-ci.org/browse/JENKINS-37731)

Note that we're pretty much stuck with SCMTrigger not working right
with the snippet generator pre-core-2.21 (or whenever
https://github.com/jenkinsci/jenkins/pull/2526 lands). SCMTrigger is
just busted vis a vis the Snippet Generator. So what we're doing here
is testing runtime syntax, and snippet generation against core with a
new enough version to have the "pollScm" symbol on SCMTrigger's descriptor.

Also enabled/fixed some snippetizer round trip tests that now can
work, while I was here.

cc @reviewbybees esp @jglick @daniel-beck 