### PR TITLE
Ability to set the default Jenkinsfile, in case of absence in the version control system

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -72,6 +72,11 @@ THE SOFTWARE.
             <version>2.6</version>
         </dependency>
         <dependency>
+            <groupId>org.jenkins-ci.plugins</groupId>
+            <artifactId>config-file-provider</artifactId>
+            <version>2.11</version>
+        </dependency>
+        <dependency>
             <groupId>org.jenkins-ci.plugins.workflow</groupId>
             <artifactId>workflow-cps</artifactId>
             <version>2.10</version>

--- a/src/main/java/org/jenkinsci/plugins/workflow/multibranch/LocalSCMBinder.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/multibranch/LocalSCMBinder.java
@@ -30,7 +30,8 @@ public class LocalSCMBinder extends SCMBinder {
 
     @Override
     public FlowExecution create(FlowExecutionOwner handle, TaskListener listener, List<? extends Action> actions) throws Exception {
-        if (Jenkins.getInstance().getWorkspaceFor(((WorkflowRun) handle.getExecutable()).getParent()).child(WorkflowBranchLocalProjectFactory.SCRIPT).exists()) {
+        if (Jenkins.getInstance() == null ||
+            Jenkins.getInstance().getWorkspaceFor(((WorkflowRun) handle.getExecutable()).getParent()).child(WorkflowBranchLocalProjectFactory.SCRIPT).exists()) {
             return super.create(handle, listener, actions);
         }
 

--- a/src/main/java/org/jenkinsci/plugins/workflow/multibranch/LocalSCMBinder.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/multibranch/LocalSCMBinder.java
@@ -1,0 +1,76 @@
+package org.jenkinsci.plugins.workflow.multibranch;
+
+import hudson.Extension;
+import hudson.model.Action;
+import hudson.model.Descriptor;
+import hudson.model.DescriptorVisibilityFilter;
+import hudson.model.TaskListener;
+import jenkins.model.Jenkins;
+import org.apache.commons.io.FileUtils;
+import org.jenkinsci.lib.configprovider.ConfigProvider;
+import org.jenkinsci.lib.configprovider.model.Config;
+import org.jenkinsci.plugins.configfiles.groovy.GroovyScript;
+import org.jenkinsci.plugins.workflow.cps.CpsFlowDefinition;
+import org.jenkinsci.plugins.workflow.flow.FlowDefinitionDescriptor;
+import org.jenkinsci.plugins.workflow.flow.FlowExecution;
+import org.jenkinsci.plugins.workflow.flow.FlowExecutionOwner;
+import org.jenkinsci.plugins.workflow.job.WorkflowJob;
+import org.jenkinsci.plugins.workflow.job.WorkflowRun;
+
+import java.io.File;
+import java.util.List;
+
+/**
+ * Checks out the local default version of {@link WorkflowBranchProjectFactory#SCRIPT} in order if exist:
+ * 1. From module checkout
+ * 1. From task workspace directory
+ * 2. From global jenkins managed files
+ */
+public class LocalSCMBinder extends SCMBinder {
+
+    @Override
+    public FlowExecution create(FlowExecutionOwner handle, TaskListener listener, List<? extends Action> actions) throws Exception {
+        if (Jenkins.getInstance().getWorkspaceFor(((WorkflowRun) handle.getExecutable()).getParent()).child(WorkflowBranchLocalProjectFactory.SCRIPT).exists()) {
+            return super.create(handle, listener, actions);
+        }
+
+        File localConfig = new File(((WorkflowJob) handle.getExecutable().getParent()).getParent().getRootDir() + File.separator + WorkflowBranchLocalProjectFactory.SCRIPT);
+        if (localConfig.exists()) {
+            return new CpsFlowDefinition(FileUtils.readFileToString(localConfig, "utf-8"), false).create(handle, listener, actions);
+        }
+        ConfigProvider configProvider = ConfigProvider.getByIdOrNull(GroovyScript.class.getName());
+        if (configProvider != null) {
+            Config config = configProvider.getConfigById(WorkflowBranchLocalProjectFactory.SCRIPT);
+            if (config != null) {
+                return new CpsFlowDefinition(config.content, false).create(handle, listener, actions);
+            }
+        }
+        throw new IllegalArgumentException(WorkflowBranchLocalProjectFactory.SCRIPT + " not found");
+    }
+
+    @Extension
+    public static class DescriptorImpl extends FlowDefinitionDescriptor {
+
+        @Override
+        public String getDisplayName() {
+           return "Pipeline script from default " + WorkflowBranchProjectFactory.SCRIPT;
+        }
+
+    }
+
+    /**
+     * Want to display this in the r/o configuration for a branch project, but not offer it on standalone jobs or in any other context.
+     */
+    @Extension
+    public static class HideMeElsewhere extends DescriptorVisibilityFilter {
+
+        @Override
+        public boolean filter(Object context, Descriptor descriptor) {
+            if (descriptor instanceof DescriptorImpl) {
+                return context instanceof WorkflowJob && ((WorkflowJob) context).getParent() instanceof WorkflowMultiBranchProject;
+            }
+            return true;
+        }
+
+    }
+}

--- a/src/main/java/org/jenkinsci/plugins/workflow/multibranch/WorkflowBranchLocalProjectFactory.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/multibranch/WorkflowBranchLocalProjectFactory.java
@@ -1,0 +1,67 @@
+/*
+ * The MIT License
+ *
+ * Copyright 2015 CloudBees, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package org.jenkinsci.plugins.workflow.multibranch;
+
+import hudson.Extension;
+import hudson.model.TaskListener;
+import jenkins.branch.MultiBranchProject;
+import jenkins.scm.api.SCMSource;
+import jenkins.scm.api.SCMSourceCriteria;
+import org.jenkinsci.plugins.workflow.flow.FlowDefinition;
+import org.kohsuke.stapler.DataBoundConstructor;
+
+import java.io.IOException;
+
+/**
+ * Recognizes and builds by default {@code Jenkinsfile}.
+ */
+public class WorkflowBranchLocalProjectFactory extends WorkflowBranchProjectFactory {
+
+    @DataBoundConstructor public WorkflowBranchLocalProjectFactory() {}
+
+    @Override protected FlowDefinition createDefinition() {
+        return new LocalSCMBinder();
+    }
+
+    @Override protected SCMSourceCriteria getSCMSourceCriteria(SCMSource source) {
+        return new SCMSourceCriteria() {
+            @Override public boolean isHead(Probe probe, TaskListener listener) throws IOException {
+                return true;
+            }
+        };
+    }
+
+    @Extension public static class DescriptorDefaultImpl extends AbstractWorkflowBranchProjectFactoryDescriptor {
+        @Override
+        public boolean isApplicable(Class<? extends MultiBranchProject> clazz) {
+            return super.isApplicable(clazz);
+        }
+
+        @Override public String getDisplayName() {
+            return "by default " + SCRIPT;
+        }
+
+    }
+}

--- a/src/main/resources/org/jenkinsci/plugins/workflow/multibranch/WorkflowBranchLocalProjectFactory/config.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/workflow/multibranch/WorkflowBranchLocalProjectFactory/config.jelly
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+The MIT License
+
+Copyright 2015 CloudBees, Inc.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+-->
+
+<?jelly escape-by-default='true'?>
+<j:jelly xmlns:j="jelly:core">
+    <!-- TODO alternately, hide the selector, as in LiterateMultibranchProject/configure-factory.jelly -->
+</j:jelly>

--- a/src/main/resources/org/jenkinsci/plugins/workflow/multibranch/WorkflowBranchLocalProjectFactory/getting-started.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/workflow/multibranch/WorkflowBranchLocalProjectFactory/getting-started.jelly
@@ -1,0 +1,30 @@
+<!--
+ ~ The MIT License
+ ~
+ ~ Copyright (c) 2016, CloudBees, Inc.
+ ~
+ ~ Permission is hereby granted, free of charge, to any person obtaining a copy
+ ~ of this software and associated documentation files (the "Software"), to deal
+ ~ in the Software without restriction, including without limitation the rights
+ ~ to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ ~ copies of the Software, and to permit persons to whom the Software is
+ ~ furnished to do so, subject to the following conditions:
+ ~
+ ~ The above copyright notice and this permission notice shall be included in
+ ~ all copies or substantial portions of the Software.
+ ~
+ ~ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ ~ IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ ~ FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ ~ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ ~ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ ~ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ ~ THE SOFTWARE.
+ -->
+<?jelly escape-by-default='true'?>
+<st:compress xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:f="/lib/form">
+  Pipeline Branch projects support building branches within a repository with a file named <code>Jenkinsfile</code> in the root directory.
+  This file should contain a valid 
+  <a target="_blank" href="https://github.com/jenkinsci/workflow-plugin/blob/master/TUTORIAL.md#understanding-flow-scripts">Jenkins Pipeline script</a>. See also: 
+  <a target="_blank" href="https://github.com/jenkinsci/workflow-plugin/blob/master/TUTORIAL.md#creating-multibranch-projects">Creating Multibranch Projects</a>.
+</st:compress>


### PR DESCRIPTION
We have 100500 units in the project. Most of them are collected and deploy same. Keep and update scripts in an amount in a version control system is impossible. But it is possible to proceed as follows (in order of priority reduction):
1. Check for Jenkinsfile at checkout.
2. Check for Jenkinsfile in job workspace folder
3. Use a globally defined default Jenkinsfile (plugin config-file-provider https://wiki.jenkins-ci.org/display/JENKINS/Config+File+Provider+Plugin)

At the same time, one does not prevent us to determine the specific configuration in paragraphs 1 and 2. As well as the actual load Jenkinsfile from SCM in paragraph 3