### PR TITLE
Adapting test to run with or without parameter behavior updates

### DIFF
--- a/src/test/java/org/jenkinsci/plugins/workflow/multibranch/JobPropertyStepTest.java
+++ b/src/test/java/org/jenkinsci/plugins/workflow/multibranch/JobPropertyStepTest.java
@@ -166,7 +166,8 @@ public class JobPropertyStepTest {
                 (HAVE_SYMBOL ?
                     "properties([parameters([string(name: 'myparam', defaultValue: 'default value')])])\n" :
                     "properties([[$class: 'ParametersDefinitionProperty', parameterDefinitions: [[$class: 'StringParameterDefinition', name: 'myparam', defaultValue: 'default value']]]])\n") +
-                "echo \"received ${binding.hasVariable('myparam') ? myparam : 'undefined'}\"");
+                // workflow-job 2.7+ / workflow-cps 2.18+: use simply ${params.myparam ?: 'undefined'}
+                "echo \"received ${env.myparam ?: binding.hasVariable('myparam') ? myparam : 'undefined'}\"");
         sampleRepo.git("add", "Jenkinsfile");
         sampleRepo.git("commit", "--all", "--message=flow");
         WorkflowMultiBranchProject mp = r.jenkins.createProject(WorkflowMultiBranchProject.class, "p");


### PR DESCRIPTION
After https://github.com/jenkinsci/workflow-cps-plugin/pull/60 + https://github.com/jenkinsci/workflow-job-plugin/pull/24 build parameters come in principally as environment variables, rather than as entries in the Groovy `[Script.]binding`; *defined* parameters can still be accessed as if they were in the binding, due to the fallback to `env`, but `binding` itself does not list them.

That means the original hack for using `ParametersDefinitionProperty` from a multibranch `Jenkinsfile` no longer works. The variant here works with or without those updates; the commented-out syntax is the intended usage going forward (and one of the motivations for making these changes to begin with).

@reviewbybees esp. @abayer