### PR TITLE
[JENKINS-33273] Use SCMFileSystem where available

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -80,12 +80,12 @@ THE SOFTWARE.
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>scm-api</artifactId>
-            <version>2.0.1-beta-1</version>
+            <version>2.0.1-beta-3</version>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>branch-api</artifactId>
-            <version>2.0.0-beta-1</version>
+            <version>2.0.0-beta-3</version>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
@@ -162,7 +162,7 @@ THE SOFTWARE.
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>git</artifactId>
-            <version>3.0.0</version>
+            <version>3.0.2-beta-2</version>
             <scope>test</scope>
             <exclusions>
                 <exclusion>
@@ -180,7 +180,7 @@ THE SOFTWARE.
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>git</artifactId>
-            <version>3.0.0</version>
+            <version>3.0.2-beta-2</version>
             <classifier>tests</classifier>
             <scope>test</scope>
             <exclusions>

--- a/src/main/java/org/jenkinsci/plugins/workflow/multibranch/ReadTrustedStep.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/multibranch/ReadTrustedStep.java
@@ -24,6 +24,7 @@
 
 package org.jenkinsci.plugins.workflow.multibranch;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import hudson.AbortException;
 import hudson.Extension;
 import hudson.FilePath;
@@ -84,6 +85,7 @@ public class ReadTrustedStep extends AbstractStepImpl {
         @StepContextParameter private transient Run<?,?> build;
         @StepContextParameter private transient TaskListener listener;
 
+        @SuppressFBWarnings(value="RCN_REDUNDANT_NULLCHECK_OF_NULL_VALUE", justification="FB thinks standaloneSCM is known to be null, but this seems like a FB bug")
         @Override protected String run() throws Exception {
             Job<?, ?> job = build.getParent();
             // Portions adapted from SCMBinder, SCMVar, and CpsScmFlowDefinition:

--- a/src/main/java/org/jenkinsci/plugins/workflow/multibranch/ReadTrustedStep.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/multibranch/ReadTrustedStep.java
@@ -83,6 +83,7 @@ public class ReadTrustedStep extends AbstractStepImpl {
 
         @Override protected String run() throws Exception {
             Job<?, ?> job = build.getParent();
+            // TODO try using SCMFileSystem
             // Adapted from CpsScmFlowDefinition:
             Node node = Jenkins.getActiveInstance();
             FilePath dir;

--- a/src/main/java/org/jenkinsci/plugins/workflow/multibranch/ReadTrustedStep.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/multibranch/ReadTrustedStep.java
@@ -176,8 +176,9 @@ public class ReadTrustedStep extends AbstractStepImpl {
                     untrustedFile = tipFS.child(step.path).contentAsString();
                 }
                 content = trustedFS.child(step.path).contentAsString();
-                listener.getLogger().println("Obtained " + step.path + " from " + head.getName());
+                listener.getLogger().println("Obtained " + step.path + " from " + trusted);
             } else {
+                listener.getLogger().println("Checking out " + head.getName() + " to read " + step.path);
                 try (WorkspaceList.Lease lease = computer.getWorkspaceList().acquire(dir)) {
                     if (trustCheck) {
                         SCMStep delegate = new GenericSCMStep(scmSource.build(head, tip));

--- a/src/main/java/org/jenkinsci/plugins/workflow/multibranch/ReadTrustedStep.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/multibranch/ReadTrustedStep.java
@@ -27,6 +27,7 @@ package org.jenkinsci.plugins.workflow.multibranch;
 import hudson.AbortException;
 import hudson.Extension;
 import hudson.FilePath;
+import hudson.Functions;
 import hudson.model.Computer;
 import hudson.model.ItemGroup;
 import hudson.model.Job;
@@ -34,11 +35,13 @@ import hudson.model.Node;
 import hudson.model.Run;
 import hudson.model.TaskListener;
 import hudson.model.TopLevelItem;
+import hudson.scm.SCM;
 import hudson.slaves.WorkspaceList;
 import java.io.IOException;
 import javax.inject.Inject;
 import jenkins.branch.Branch;
 import jenkins.model.Jenkins;
+import jenkins.scm.api.SCMFileSystem;
 import jenkins.scm.api.SCMHead;
 import jenkins.scm.api.SCMRevision;
 import jenkins.scm.api.SCMRevisionAction;
@@ -83,8 +86,31 @@ public class ReadTrustedStep extends AbstractStepImpl {
 
         @Override protected String run() throws Exception {
             Job<?, ?> job = build.getParent();
-            // TODO try using SCMFileSystem
-            // Adapted from CpsScmFlowDefinition:
+            // Portions adapted from SCMBinder, SCMVar, and CpsScmFlowDefinition:
+            SCM standaloneSCM = null;
+            BranchJobProperty property = job.getProperty(BranchJobProperty.class);
+            if (property == null) {
+                if (job instanceof WorkflowJob) {
+                    FlowDefinition defn = ((WorkflowJob) job).getDefinition();
+                    if (defn instanceof CpsScmFlowDefinition) {
+                        // JENKINS-31386: retrofit to work with standalone projects, without doing any trust checks.
+                        standaloneSCM = ((CpsScmFlowDefinition) defn).getScm();
+                        SCMFileSystem fs = SCMFileSystem.of(job, standaloneSCM);
+                        if (fs != null) { // JENKINS-33273
+                            try {
+                                String text = fs.child(step.path).contentAsString();
+                                listener.getLogger().println("Obtained " + step.path + " from " + standaloneSCM.getKey());
+                                return text;
+                            } catch (IOException | InterruptedException x) {
+                                listener.error("Could not do lightweight checkout, falling back to heavyweight").println(Functions.printThrowable(x).trim());
+                            }
+                        }
+                    }
+                }
+                throw new AbortException("‘readTrusted’ is only available when using “" +
+                    Jenkins.getActiveInstance().getDescriptorByType(WorkflowMultiBranchProject.DescriptorImpl.class).getDisplayName() +
+                    "” or “" + Jenkins.getActiveInstance().getDescriptorByType(CpsScmFlowDefinition.DescriptorImpl.class).getDisplayName() + "”");
+            }
             Node node = Jenkins.getActiveInstance();
             FilePath dir;
             if (job instanceof TopLevelItem) {
@@ -104,78 +130,77 @@ public class ReadTrustedStep extends AbstractStepImpl {
             if (computer == null) {
                 throw new IOException(node.getDisplayName() + " may be offline");
             }
-            WorkspaceList.Lease lease = computer.getWorkspaceList().acquire(dir);
-            try {
-                // Adapted from SCMBinder:
-                BranchJobProperty property = job.getProperty(BranchJobProperty.class);
-                if (property == null) {
-                    // As in SCMVar:
-                    if (job instanceof WorkflowJob) {
-                        FlowDefinition defn = ((WorkflowJob) job).getDefinition();
-                        if (defn instanceof CpsScmFlowDefinition) {
-                            // JENKINS-31386: retrofit to work with standalone projects, without doing any trust checks.
-                            SCMStep delegate = new GenericSCMStep(((CpsScmFlowDefinition) defn).getScm());
-                            delegate.setPoll(true);
-                            delegate.setChangelog(true);
-                            delegate.checkout(build, dir, listener, node.createLauncher(listener));
-                            if (!file.exists()) {
-                                throw new AbortException(file + " not found");
-                            }
-                            return file.readToString();
-                        }
-                    }
-                    throw new AbortException("‘readTrusted’ is only available when using “" +
-                        Jenkins.getActiveInstance().getDescriptorByType(WorkflowMultiBranchProject.DescriptorImpl.class).getDisplayName() +
-                        "” or “" + Jenkins.getActiveInstance().getDescriptorByType(CpsScmFlowDefinition.DescriptorImpl.class).getDisplayName() + "”");
-                }
-                Branch branch = property.getBranch();
-                ItemGroup<?> parent = job.getParent();
-                if (!(parent instanceof WorkflowMultiBranchProject)) {
-                    throw new IllegalStateException("inappropriate context");
-                }
-                SCMSource scmSource = ((WorkflowMultiBranchProject) parent).getSCMSource(branch.getSourceId());
-                if (scmSource == null) {
-                    throw new IllegalStateException(branch.getSourceId() + " not found");
-                }
-                SCMHead head = branch.getHead();
-                SCMRevision tip;
-                SCMRevisionAction action = build.getAction(SCMRevisionAction.class);
-                if (action != null) {
-                    tip = action.getRevision();
-                } else {
-                    tip = scmSource.fetch(head, listener);
-                    if (tip == null) {
-                        throw new AbortException("Could not determine exact tip revision of " + branch.getName());
-                    }
-                    build.addAction(new SCMRevisionAction(tip));
-                }
-                SCMRevision trusted = scmSource.getTrustedRevision(tip, listener);
-                String untrustedFile = null;
-                if (!tip.equals(trusted)) {
-                    SCMStep delegate = new GenericSCMStep(scmSource.build(head, tip));
-                    delegate.setPoll(false);
-                    delegate.setChangelog(false);
+            if (standaloneSCM != null) {
+                try (WorkspaceList.Lease lease = computer.getWorkspaceList().acquire(dir)) {
+                    SCMStep delegate = new GenericSCMStep(standaloneSCM);
+                    delegate.setPoll(true);
+                    delegate.setChangelog(true);
                     delegate.checkout(build, dir, listener, node.createLauncher(listener));
                     if (!file.exists()) {
                         throw new AbortException(file + " not found");
                     }
-                    untrustedFile = file.readToString();
+                    return file.readToString();
                 }
-                SCMStep delegate = new GenericSCMStep(scmSource.build(head, trusted));
-                delegate.setPoll(true);
-                delegate.setChangelog(true);
-                delegate.checkout(build, dir, listener, node.createLauncher(listener));
-                if (!file.exists()) {
-                    throw new AbortException(file + " not found");
-                }
-                String content = file.readToString();
-                if (untrustedFile != null && !untrustedFile.equals(content)) {
-                    throw new AbortException(Messages.ReadTrustedStep__has_been_modified_in_an_untrusted_revis(step.path));
-                }
-                return content;
-            } finally {
-                lease.release();
             }
+            Branch branch = property.getBranch();
+            ItemGroup<?> parent = job.getParent();
+            if (!(parent instanceof WorkflowMultiBranchProject)) {
+                throw new IllegalStateException("inappropriate context");
+            }
+            SCMSource scmSource = ((WorkflowMultiBranchProject) parent).getSCMSource(branch.getSourceId());
+            if (scmSource == null) {
+                throw new IllegalStateException(branch.getSourceId() + " not found");
+            }
+            SCMHead head = branch.getHead();
+            SCMRevision tip;
+            SCMRevisionAction action = build.getAction(SCMRevisionAction.class);
+            if (action != null) {
+                tip = action.getRevision();
+            } else {
+                tip = scmSource.fetch(head, listener);
+                if (tip == null) {
+                    throw new AbortException("Could not determine exact tip revision of " + branch.getName());
+                }
+                build.addAction(new SCMRevisionAction(tip));
+            }
+            SCMRevision trusted = scmSource.getTrustedRevision(tip, listener);
+            boolean trustCheck = !tip.equals(trusted);
+            String untrustedFile = null;
+            String content;
+            SCMFileSystem tipFS = trustCheck ? SCMFileSystem.of(scmSource, head, tip) : null;
+            SCMFileSystem trustedFS = SCMFileSystem.of(scmSource, head, trusted);
+            if (trustedFS != null && (!trustCheck || tipFS != null)) {
+                if (trustCheck) {
+                    untrustedFile = tipFS.child(step.path).contentAsString();
+                }
+                content = trustedFS.child(step.path).contentAsString();
+                listener.getLogger().println("Obtained " + step.path + " from " + head.getName());
+            } else {
+                try (WorkspaceList.Lease lease = computer.getWorkspaceList().acquire(dir)) {
+                    if (trustCheck) {
+                        SCMStep delegate = new GenericSCMStep(scmSource.build(head, tip));
+                        delegate.setPoll(false);
+                        delegate.setChangelog(false);
+                        delegate.checkout(build, dir, listener, node.createLauncher(listener));
+                        if (!file.exists()) {
+                            throw new AbortException(file + " not found");
+                        }
+                        untrustedFile = file.readToString();
+                    }
+                    SCMStep delegate = new GenericSCMStep(scmSource.build(head, trusted));
+                    delegate.setPoll(true);
+                    delegate.setChangelog(true);
+                    delegate.checkout(build, dir, listener, node.createLauncher(listener));
+                    if (!file.exists()) {
+                        throw new AbortException(file + " not found");
+                    }
+                    content = file.readToString();
+                }
+            }
+            if (trustCheck && !untrustedFile.equals(content)) {
+                throw new AbortException(Messages.ReadTrustedStep__has_been_modified_in_an_untrusted_revis(step.path));
+            }
+            return content;
         }
 
         private FilePath getFilePathWithSuffix(FilePath baseWorkspace) {

--- a/src/main/java/org/jenkinsci/plugins/workflow/multibranch/SCMBinder.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/multibranch/SCMBinder.java
@@ -82,11 +82,11 @@ class SCMBinder extends FlowDefinition {
             build.addAction(new SCMRevisionAction(tip));
             SCMRevision rev = scmSource.getTrustedRevision(tip, listener);
             SCMFileSystem fs = SCMFileSystem.of(scmSource, head, rev);
-            if (fs != null) { // JENKINS-33273; TODO perhaps this should be pushed down into CpsScmFlowDefinition?
-                listener.getLogger().println("Performing lightweight checkout");
+            if (fs != null) { // JENKINS-33273
                 String script = null;
                 try {
                     script = fs.child(WorkflowBranchProjectFactory.SCRIPT).contentAsString();
+                    listener.getLogger().println("Obtained " + WorkflowBranchProjectFactory.SCRIPT + " from " + head.getName());
                 } catch (IOException | InterruptedException x) {
                     listener.error("Could not do lightweight checkout, falling back to heavyweight").println(Functions.printThrowable(x).trim());
                 }

--- a/src/main/java/org/jenkinsci/plugins/workflow/multibranch/SCMBinder.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/multibranch/SCMBinder.java
@@ -25,6 +25,7 @@
 package org.jenkinsci.plugins.workflow.multibranch;
 
 import hudson.Extension;
+import hudson.Functions;
 import hudson.model.Action;
 import hudson.model.Descriptor;
 import hudson.model.DescriptorVisibilityFilter;
@@ -32,12 +33,15 @@ import hudson.model.ItemGroup;
 import hudson.model.Queue;
 import hudson.model.TaskListener;
 import hudson.scm.SCM;
+import java.io.IOException;
 import java.util.List;
 import jenkins.branch.Branch;
+import jenkins.scm.api.SCMFileSystem;
 import jenkins.scm.api.SCMHead;
 import jenkins.scm.api.SCMRevision;
 import jenkins.scm.api.SCMRevisionAction;
 import jenkins.scm.api.SCMSource;
+import org.jenkinsci.plugins.workflow.cps.CpsFlowDefinition;
 import org.jenkinsci.plugins.workflow.cps.CpsScmFlowDefinition;
 import org.jenkinsci.plugins.workflow.flow.FlowDefinition;
 import org.jenkinsci.plugins.workflow.flow.FlowDefinitionDescriptor;
@@ -75,8 +79,22 @@ class SCMBinder extends FlowDefinition {
         SCMRevision tip = scmSource.fetch(head, listener);
         SCM scm;
         if (tip != null) {
-            scm = scmSource.build(head, scmSource.getTrustedRevision(tip, listener));
             build.addAction(new SCMRevisionAction(tip));
+            SCMRevision rev = scmSource.getTrustedRevision(tip, listener);
+            SCMFileSystem fs = SCMFileSystem.of(scmSource, head, rev);
+            if (fs != null) { // JENKINS-33273; TODO perhaps this should be pushed down into CpsScmFlowDefinition?
+                listener.getLogger().println("Performing lightweight checkout");
+                String script = null;
+                try {
+                    script = fs.child(WorkflowBranchProjectFactory.SCRIPT).contentAsString();
+                } catch (IOException | InterruptedException x) {
+                    listener.error("Could not do lightweight checkout, falling back to heavyweight").println(Functions.printThrowable(x).trim());
+                }
+                if (script != null) {
+                    return new CpsFlowDefinition(script, true).create(handle, listener, actions);
+                }
+            }
+            scm = scmSource.build(head, rev);
         } else {
             listener.error("Could not determine exact tip revision of " + branch.getName() + "; falling back to nondeterministic checkout");
             // Build might fail later anyway, but reason should become clear: for example, branch was deleted before indexing could run.
@@ -96,6 +114,7 @@ class SCMBinder extends FlowDefinition {
     /** Want to display this in the r/o configuration for a branch project, but not offer it on standalone jobs or in any other context. */
     @Extension public static class HideMeElsewhere extends DescriptorVisibilityFilter {
 
+        @SuppressWarnings("rawtypes")
         @Override public boolean filter(Object context, Descriptor descriptor) {
             if (descriptor instanceof DescriptorImpl) {
                 return context instanceof WorkflowJob && ((WorkflowJob) context).getParent() instanceof WorkflowMultiBranchProject;

--- a/src/main/java/org/jenkinsci/plugins/workflow/multibranch/SCMBinder.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/multibranch/SCMBinder.java
@@ -86,7 +86,7 @@ class SCMBinder extends FlowDefinition {
                 String script = null;
                 try {
                     script = fs.child(WorkflowBranchProjectFactory.SCRIPT).contentAsString();
-                    listener.getLogger().println("Obtained " + WorkflowBranchProjectFactory.SCRIPT + " from " + head.getName());
+                    listener.getLogger().println("Obtained " + WorkflowBranchProjectFactory.SCRIPT + " from " + rev);
                 } catch (IOException | InterruptedException x) {
                     listener.error("Could not do lightweight checkout, falling back to heavyweight").println(Functions.printThrowable(x).trim());
                 }

--- a/src/test/java/org/jenkinsci/plugins/workflow/multibranch/ReadTrustedStepTest.java
+++ b/src/test/java/org/jenkinsci/plugins/workflow/multibranch/ReadTrustedStepTest.java
@@ -62,7 +62,7 @@ public class ReadTrustedStepTest {
         SCMBinderTest.assertRevisionAction(b);
         r.assertBuildStatusSuccess(b);
         r.assertLogContains("said how do you do", b);
-        r.assertLogContains("Obtained message from master", b);
+        r.assertLogContains("Obtained message from ", b);
         String branch = "evil";
         sampleRepo.git("checkout", "-b", branch);
         sampleRepo.write("message", "your father smelt of elderberries");
@@ -75,7 +75,7 @@ public class ReadTrustedStepTest {
         SCMBinderTest.assertRevisionAction(b);
         r.assertBuildStatus(Result.FAILURE, b);
         r.assertLogContains(Messages.ReadTrustedStep__has_been_modified_in_an_untrusted_revis("message"), b);
-        r.assertLogContains("Obtained message from evil", b);
+        r.assertLogContains("Obtained message from ", b);
         sampleRepo.write("message", "how do you do");
         sampleRepo.write("ignored-message", "I fart in your general direction");
         sampleRepo.git("add", "ignored-message");
@@ -86,7 +86,7 @@ public class ReadTrustedStepTest {
         SCMBinderTest.assertRevisionAction(b);
         r.assertBuildStatusSuccess(b);
         r.assertLogContains("said how do you do", b);
-        r.assertLogContains("Obtained message from evil", b);
+        r.assertLogContains("Obtained message from ", b);
     }
 
     @Test public void exactRevision() throws Exception {

--- a/src/test/java/org/jenkinsci/plugins/workflow/multibranch/ReadTrustedStepTest.java
+++ b/src/test/java/org/jenkinsci/plugins/workflow/multibranch/ReadTrustedStepTest.java
@@ -25,9 +25,7 @@
 package org.jenkinsci.plugins.workflow.multibranch;
 
 import hudson.model.Result;
-import jenkins.branch.BranchProperty;
 import jenkins.branch.BranchSource;
-import jenkins.branch.DefaultBranchPropertyStrategy;
 import jenkins.plugins.git.GitSampleRepoRule;
 import jenkins.plugins.git.GitStep;
 import org.jenkinsci.plugins.workflow.cps.CpsScmFlowDefinition;
@@ -55,7 +53,7 @@ public class ReadTrustedStepTest {
         sampleRepo.git("add", "Jenkinsfile", "message");
         sampleRepo.git("commit", "--all", "--message=defined");
         WorkflowMultiBranchProject mp = r.jenkins.createProject(WorkflowMultiBranchProject.class, "p");
-        mp.getSourcesList().add(new BranchSource(new SCMBinderTest.WarySource(null, sampleRepo.toString(), "", "*", "", false), new DefaultBranchPropertyStrategy(new BranchProperty[0])));
+        mp.getSourcesList().add(new BranchSource(new SCMBinderTest.WarySource(null, sampleRepo.toString(), "", "*", "", false)));
         WorkflowJob p = WorkflowMultiBranchProjectTest.scheduleAndFindBranchProject(mp, "master");
         r.waitUntilNoActivity();
         WorkflowRun b = p.getLastBuild();
@@ -64,6 +62,7 @@ public class ReadTrustedStepTest {
         SCMBinderTest.assertRevisionAction(b);
         r.assertBuildStatusSuccess(b);
         r.assertLogContains("said how do you do", b);
+        r.assertLogContains("Obtained message from master", b);
         String branch = "evil";
         sampleRepo.git("checkout", "-b", branch);
         sampleRepo.write("message", "your father smelt of elderberries");
@@ -76,6 +75,7 @@ public class ReadTrustedStepTest {
         SCMBinderTest.assertRevisionAction(b);
         r.assertBuildStatus(Result.FAILURE, b);
         r.assertLogContains(Messages.ReadTrustedStep__has_been_modified_in_an_untrusted_revis("message"), b);
+        r.assertLogContains("Obtained message from evil", b);
         sampleRepo.write("message", "how do you do");
         sampleRepo.write("ignored-message", "I fart in your general direction");
         sampleRepo.git("add", "ignored-message");
@@ -86,6 +86,7 @@ public class ReadTrustedStepTest {
         SCMBinderTest.assertRevisionAction(b);
         r.assertBuildStatusSuccess(b);
         r.assertLogContains("said how do you do", b);
+        r.assertLogContains("Obtained message from evil", b);
     }
 
     @Test public void exactRevision() throws Exception {
@@ -96,7 +97,7 @@ public class ReadTrustedStepTest {
         sampleRepo.git("add", "Jenkinsfile", "alpha", "beta");
         sampleRepo.git("commit", "--all", "--message=defined");
         WorkflowMultiBranchProject mp = r.jenkins.createProject(WorkflowMultiBranchProject.class, "p");
-        mp.getSourcesList().add(new BranchSource(new SCMBinderTest.WarySource(null, sampleRepo.toString(), "", "*", "", false), new DefaultBranchPropertyStrategy(new BranchProperty[0])));
+        mp.getSourcesList().add(new BranchSource(new SCMBinderTest.WarySource(null, sampleRepo.toString(), "", "*", "", false)));
         WorkflowJob p = WorkflowMultiBranchProjectTest.scheduleAndFindBranchProject(mp, "master");
         SemaphoreStep.waitForStart("wait1/1", null);
         WorkflowRun b = p.getLastBuild();
@@ -132,7 +133,7 @@ public class ReadTrustedStepTest {
         sampleRepo.git("add", "Jenkinsfile", "lib.groovy");
         sampleRepo.git("commit", "--all", "--message=defined");
         WorkflowMultiBranchProject mp = r.jenkins.createProject(WorkflowMultiBranchProject.class, "p");
-        mp.getSourcesList().add(new BranchSource(new SCMBinderTest.WarySource(null, sampleRepo.toString(), "", "*", "", false), new DefaultBranchPropertyStrategy(new BranchProperty[0])));
+        mp.getSourcesList().add(new BranchSource(new SCMBinderTest.WarySource(null, sampleRepo.toString(), "", "*", "", false)));
         WorkflowJob p = WorkflowMultiBranchProjectTest.scheduleAndFindBranchProject(mp, "master");
         r.waitUntilNoActivity();
         WorkflowRun b = p.getLastBuild();
@@ -164,9 +165,13 @@ public class ReadTrustedStepTest {
         sampleRepo.git("add", "Jenkinsfile", "message");
         sampleRepo.git("commit", "--all", "--message=defined");
         WorkflowJob p = r.jenkins.createProject(WorkflowJob.class, "p");
-        p.setDefinition(new CpsScmFlowDefinition(new GitStep(sampleRepo.toString()).createSCM(), "Jenkinsfile"));
+        GitStep step = new GitStep(sampleRepo.toString());
+        step.setCredentialsId("nonexistent"); // TODO work around NPE pending https://github.com/jenkinsci/git-plugin/pull/467
+        p.setDefinition(new CpsScmFlowDefinition(step.createSCM(), "Jenkinsfile"));
+        // TODO after https://github.com/jenkinsci/workflow-cps-plugin/pull/97 could setLightweight(true)
         WorkflowRun b = r.assertBuildStatusSuccess(p.scheduleBuild2(0));
         r.assertLogContains("said how do you do", b);
+        r.assertLogContains("Obtained message from git ", b);
     }
 
 }

--- a/src/test/java/org/jenkinsci/plugins/workflow/multibranch/SCMBinderTest.java
+++ b/src/test/java/org/jenkinsci/plugins/workflow/multibranch/SCMBinderTest.java
@@ -84,7 +84,7 @@ public class SCMBinderTest {
         assertNotNull(b1);
         assertEquals(1, b1.getNumber());
         assertRevisionAction(b1);
-        r.assertLogContains("Obtained Jenkinsfile from master", b1);
+        r.assertLogContains("Obtained Jenkinsfile from ", b1);
         sampleGitRepo.write("Jenkinsfile", "node {checkout scm; echo readFile('file').toUpperCase()}");
         sampleGitRepo.write("file", "subsequent content");
         sampleGitRepo.git("commit", "--all", "--message=tweaked");

--- a/src/test/java/org/jenkinsci/plugins/workflow/multibranch/SCMBinderTest.java
+++ b/src/test/java/org/jenkinsci/plugins/workflow/multibranch/SCMBinderTest.java
@@ -36,9 +36,7 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Set;
 import java.util.TreeSet;
-import jenkins.branch.BranchProperty;
 import jenkins.branch.BranchSource;
-import jenkins.branch.DefaultBranchPropertyStrategy;
 import jenkins.model.Jenkins;
 import jenkins.plugins.git.AbstractGitSCMSource;
 import jenkins.plugins.git.GitSCMSource;
@@ -79,13 +77,14 @@ public class SCMBinderTest {
         sampleGitRepo.git("add", "Jenkinsfile");
         sampleGitRepo.git("commit", "--all", "--message=flow");
         WorkflowMultiBranchProject mp = r.jenkins.createProject(WorkflowMultiBranchProject.class, "p");
-        mp.getSourcesList().add(new BranchSource(new GitSCMSource(null, sampleGitRepo.toString(), "", "*", "", false), new DefaultBranchPropertyStrategy(new BranchProperty[0])));
+        mp.getSourcesList().add(new BranchSource(new GitSCMSource(null, sampleGitRepo.toString(), "", "*", "", false)));
         WorkflowJob p = WorkflowMultiBranchProjectTest.scheduleAndFindBranchProject(mp, "master");
         SemaphoreStep.waitForStart("wait/1", null);
         WorkflowRun b1 = p.getLastBuild();
         assertNotNull(b1);
         assertEquals(1, b1.getNumber());
         assertRevisionAction(b1);
+        r.assertLogContains("Performing lightweight checkout", b1);
         sampleGitRepo.write("Jenkinsfile", "node {checkout scm; echo readFile('file').toUpperCase()}");
         sampleGitRepo.write("file", "subsequent content");
         sampleGitRepo.git("commit", "--all", "--message=tweaked");
@@ -115,11 +114,14 @@ public class SCMBinderTest {
         assertNotNull(revisionAction);
         SCMRevision revision = revisionAction.getRevision();
         assertEquals(AbstractGitSCMSource.SCMRevisionImpl.class, revision.getClass());
-        Set<String> expected = new HashSet<String>();
-        for (BuildData data : build.getActions(BuildData.class)) {
-            expected.add(data.lastBuild.marked.getSha1().getName());
+        Set<String> expected = new HashSet<>();
+        List<BuildData> buildDataActions = build.getActions(BuildData.class);
+        if (!buildDataActions.isEmpty()) { // i.e., we have run at least one checkout step, or done a heavyweight checkout to get a single file
+            for (BuildData data : buildDataActions) {
+                expected.add(data.lastBuild.marked.getSha1().getName());
+            }
+            assertThat(expected, hasItem(((AbstractGitSCMSource.SCMRevisionImpl) revision).getHash()));
         }
-        assertThat(expected, hasItem(((AbstractGitSCMSource.SCMRevisionImpl) revision).getHash()));
     }
 
     @Test public void exactRevisionSubversion() throws Exception {
@@ -132,7 +134,7 @@ public class SCMBinderTest {
         sampleSvnRepo.svnkit("add", sampleSvnRepo.wc() + "/Jenkinsfile");
         sampleSvnRepo.svnkit("commit", "--message=flow", sampleSvnRepo.wc());
         WorkflowMultiBranchProject mp = r.jenkins.createProject(WorkflowMultiBranchProject.class, "p");
-        mp.getSourcesList().add(new BranchSource(new SubversionSCMSource(null, sampleSvnRepo.prjUrl(), null, null, null), new DefaultBranchPropertyStrategy(new BranchProperty[0])));
+        mp.getSourcesList().add(new BranchSource(new SubversionSCMSource(null, sampleSvnRepo.prjUrl())));
         WorkflowJob p = WorkflowMultiBranchProjectTest.scheduleAndFindBranchProject(mp, "trunk");
         SemaphoreStep.waitForStart("wait/1", null);
         WorkflowRun b1 = p.getLastBuild();
@@ -167,7 +169,7 @@ public class SCMBinderTest {
         sampleGitRepo.git("add", "Jenkinsfile");
         sampleGitRepo.git("commit", "--all", "--message=flow");
         WorkflowMultiBranchProject mp = r.jenkins.createProject(WorkflowMultiBranchProject.class, "p");
-        mp.getSourcesList().add(new BranchSource(new GitSCMSource(null, sampleGitRepo.toString(), "", "*", "", false), new DefaultBranchPropertyStrategy(new BranchProperty[0])));
+        mp.getSourcesList().add(new BranchSource(new GitSCMSource(null, sampleGitRepo.toString(), "", "*", "", false)));
         WorkflowJob p = WorkflowMultiBranchProjectTest.scheduleAndFindBranchProject(mp, "master");
         assertEquals(1, mp.getItems().size());
         r.waitUntilNoActivity();
@@ -191,7 +193,7 @@ public class SCMBinderTest {
         sampleGitRepo.git("add", "somefile");
         sampleGitRepo.git("commit", "--all", "--message=tweaked");
         WorkflowMultiBranchProject mp = r.jenkins.createProject(WorkflowMultiBranchProject.class, "p");
-        mp.getSourcesList().add(new BranchSource(new GitSCMSource(null, sampleGitRepo.toString(), "", "*", "", false), new DefaultBranchPropertyStrategy(new BranchProperty[0])));
+        mp.getSourcesList().add(new BranchSource(new GitSCMSource(null, sampleGitRepo.toString(), "", "*", "", false)));
         WorkflowJob p = WorkflowMultiBranchProjectTest.scheduleAndFindBranchProject(mp, "feature");
         assertEquals(2, mp.getItems().size());
         r.waitUntilNoActivity();
@@ -217,7 +219,7 @@ public class SCMBinderTest {
         sampleGitRepo.git("add", "Jenkinsfile");
         sampleGitRepo.git("commit", "--all", "--message=flow");
         WorkflowMultiBranchProject mp = r.jenkins.createProject(WorkflowMultiBranchProject.class, "p");
-        mp.getSourcesList().add(new BranchSource(new WarySource(null, sampleGitRepo.toString(), "", "*", "", false), new DefaultBranchPropertyStrategy(new BranchProperty[0])));
+        mp.getSourcesList().add(new BranchSource(new WarySource(null, sampleGitRepo.toString(), "", "*", "", false)));
         WorkflowJob p = WorkflowMultiBranchProjectTest.scheduleAndFindBranchProject(mp, "master");
         r.waitUntilNoActivity();
         WorkflowRun b = p.getLastBuild();

--- a/src/test/java/org/jenkinsci/plugins/workflow/multibranch/SCMBinderTest.java
+++ b/src/test/java/org/jenkinsci/plugins/workflow/multibranch/SCMBinderTest.java
@@ -84,7 +84,7 @@ public class SCMBinderTest {
         assertNotNull(b1);
         assertEquals(1, b1.getNumber());
         assertRevisionAction(b1);
-        r.assertLogContains("Performing lightweight checkout", b1);
+        r.assertLogContains("Obtained Jenkinsfile from master", b1);
         sampleGitRepo.write("Jenkinsfile", "node {checkout scm; echo readFile('file').toUpperCase()}");
         sampleGitRepo.write("file", "subsequent content");
         sampleGitRepo.git("commit", "--all", "--message=tweaked");


### PR DESCRIPTION
[JENKINS-33273](https://issues.jenkins-ci.org/browse/JENKINS-33273)

- [X] optimize `Jenkinsfile` checkout from a branch project
- [X] optimize `CpsScmFlowDefinition` checkout from a standalone project: https://github.com/jenkinsci/workflow-cps-plugin/pull/97
- [x] optimize `readTrusted` checkout from a branch project
- [x] optimize `readTrusted` checkout from a standalone project
- [ ] sanity check using GitHub

Tests take advantage of https://github.com/jenkinsci/git-plugin/pull/455.

@reviewbybees esp.