### PR TITLE
Fix JENKINS-42045 - cannot use tags with Pipeline Multibranch

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/workflow/multibranch/SCMVar.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/multibranch/SCMVar.java
@@ -99,11 +99,10 @@ import org.jenkinsci.plugins.workflow.support.pickles.XStreamPickle;
             FlowExecutionOwner owner = ((WorkflowRun) build).asFlowExecutionOwner();
             TaskListener listener = owner != null ? owner.getListener() : TaskListener.NULL;
             tip = scmSource.fetch(head, listener);
-            if (tip == null) {
-                throw new AbortException("Could not determine exact tip revision of " + branch.getName());
+            if (tip != null) {
+                revisionAction = new SCMRevisionAction(tip);
+                build.addAction(revisionAction);
             }
-            revisionAction = new SCMRevisionAction(tip);
-            build.addAction(revisionAction);
         }
         return scmSource.build(branch.getHead(), tip);
     }


### PR DESCRIPTION
If Head is a tag rather than a branch, SCMSource.fetch returns null.
In this case, pass the null on to SCMSource.build, as this will build
the appropriate revision for the tag.