### PR TITLE
make SCMBinder class public so we can reference it outside of this pa…

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/workflow/multibranch/SCMBinder.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/multibranch/SCMBinder.java
@@ -53,7 +53,7 @@ import org.jenkinsci.plugins.workflow.job.WorkflowRun;
 /**
  * Checks out the desired version of {@link WorkflowBranchProjectFactory#SCRIPT}.
  */
-class SCMBinder extends FlowDefinition {
+public class SCMBinder extends FlowDefinition {
 
     /** Kill switch for JENKINS-33273 in case of problems. */
     static /* not final */ boolean USE_HEAVYWEIGHT_CHECKOUT = Boolean.getBoolean(SCMBinder.class.getName() + ".USE_HEAVYWEIGHT_CHECKOUT"); // TODO 2.4+ use SystemProperties


### PR DESCRIPTION
…ckage and plugin

We have a [plugin](https://github.com/fabric8io/jenkins-sync-plugin) that needs to check the job definitation before carrying out an action, i.e.

```
if (definition instanceof SCMBinder){...}
```  

This PR makes the class public so we can use the instanceof.