### PR TITLE
Make SCMBinder try to abort builds in which Jenkinsfile has been modified by an untrusted contributor

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/workflow/multibranch/SCMBinder.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/multibranch/SCMBinder.java
@@ -24,6 +24,7 @@
 
 package org.jenkinsci.plugins.workflow.multibranch;
 
+import hudson.AbortException;
 import hudson.Extension;
 import hudson.Functions;
 import hudson.model.Action;
@@ -58,6 +59,10 @@ class SCMBinder extends FlowDefinition {
 
     /** Kill switch for JENKINS-33273 in case of problems. */
     static /* not final */ boolean USE_HEAVYWEIGHT_CHECKOUT = Boolean.getBoolean(SCMBinder.class.getName() + ".USE_HEAVYWEIGHT_CHECKOUT"); // TODO 2.4+ use SystemProperties
+
+    /** Kill switch for making this as strict as {@link ReadTrustedStep} about untrusted modifications. */
+    static /* not final */ boolean IGNORE_UNTRUSTED_EDITS = Boolean.getBoolean(SCMBinder.class.getName() + ".IGNORE_UNTRUSTED_EDITS"); // TODO 2.4+ use SystemProperties
+
     private String scriptPath = WorkflowBranchProjectFactory.SCRIPT;
 
     public Object readResolve() {
@@ -107,6 +112,23 @@ class SCMBinder extends FlowDefinition {
                         listener.error("Could not do lightweight checkout, falling back to heavyweight").println(Functions.printThrowable(x).trim());
                     }
                     if (script != null) {
+                        if (!IGNORE_UNTRUSTED_EDITS && !rev.equals(tip)) {
+                            // Make a best effort to abort builds where an untrusted contributor has tried to edit Jenkinsfile.
+                            // If we fail to check this (e.g., due to heavyweight checkout), a warning will be printed to the log
+                            // and the build will continue with the trusted variant, which is safe but confusing.
+                            SCMFileSystem tipFS = SCMFileSystem.of(scmSource, head, tip);
+                            if (tipFS != null) {
+                                String tipScript = null;
+                                try {
+                                    tipScript = tipFS.child(scriptPath).contentAsString();
+                                } catch (IOException | InterruptedException x) {
+                                    listener.error("Could not compare lightweight checkout of trusted revision").println(Functions.printThrowable(x).trim());
+                                }
+                                if (tipScript != null && !script.equals(tipScript)) {
+                                    throw new AbortException(Messages.ReadTrustedStep__has_been_modified_in_an_untrusted_revis(scriptPath));
+                                }
+                            }
+                        }
                         return new CpsFlowDefinition(script, true).create(handle, listener, actions);
                     }
                 }

--- a/src/main/java/org/jenkinsci/plugins/workflow/multibranch/SCMBinder.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/multibranch/SCMBinder.java
@@ -24,9 +24,12 @@
 
 package org.jenkinsci.plugins.workflow.multibranch;
 
-import hudson.AbortException;
 import hudson.Extension;
 import hudson.Functions;
+import hudson.MarkupText;
+import hudson.console.ConsoleAnnotationDescriptor;
+import hudson.console.ConsoleAnnotator;
+import hudson.console.ConsoleNote;
 import hudson.model.Action;
 import hudson.model.Descriptor;
 import hudson.model.DescriptorVisibilityFilter;
@@ -42,7 +45,6 @@ import jenkins.scm.api.SCMHead;
 import jenkins.scm.api.SCMRevision;
 import jenkins.scm.api.SCMRevisionAction;
 import jenkins.scm.api.SCMSource;
-import org.apache.commons.lang.StringUtils;
 import org.jenkinsci.plugins.workflow.cps.CpsFlowDefinition;
 import org.jenkinsci.plugins.workflow.cps.CpsScmFlowDefinition;
 import org.jenkinsci.plugins.workflow.flow.FlowDefinition;
@@ -59,9 +61,6 @@ class SCMBinder extends FlowDefinition {
 
     /** Kill switch for JENKINS-33273 in case of problems. */
     static /* not final */ boolean USE_HEAVYWEIGHT_CHECKOUT = Boolean.getBoolean(SCMBinder.class.getName() + ".USE_HEAVYWEIGHT_CHECKOUT"); // TODO 2.4+ use SystemProperties
-
-    /** Kill switch for making this as strict as {@link ReadTrustedStep} about untrusted modifications. */
-    static /* not final */ boolean IGNORE_UNTRUSTED_EDITS = Boolean.getBoolean(SCMBinder.class.getName() + ".IGNORE_UNTRUSTED_EDITS"); // TODO 2.4+ use SystemProperties
 
     private String scriptPath = WorkflowBranchProjectFactory.SCRIPT;
 
@@ -112,10 +111,10 @@ class SCMBinder extends FlowDefinition {
                         listener.error("Could not do lightweight checkout, falling back to heavyweight").println(Functions.printThrowable(x).trim());
                     }
                     if (script != null) {
-                        if (!IGNORE_UNTRUSTED_EDITS && !rev.equals(tip)) {
-                            // Make a best effort to abort builds where an untrusted contributor has tried to edit Jenkinsfile.
-                            // If we fail to check this (e.g., due to heavyweight checkout), a warning will be printed to the log
-                            // and the build will continue with the trusted variant, which is safe but confusing.
+                        if (!rev.equals(tip)) {
+                            // Print a warning in builds where an untrusted contributor has tried to edit Jenkinsfile.
+                            // If we fail to check this (e.g., due to heavyweight checkout), a warning will still be printed to the log
+                            // by the SCM, but that is less apparent.
                             SCMFileSystem tipFS = SCMFileSystem.of(scmSource, head, tip);
                             if (tipFS != null) {
                                 String tipScript = null;
@@ -125,7 +124,9 @@ class SCMBinder extends FlowDefinition {
                                     listener.error("Could not compare lightweight checkout of trusted revision").println(Functions.printThrowable(x).trim());
                                 }
                                 if (tipScript != null && !script.equals(tipScript)) {
-                                    throw new AbortException(Messages.ReadTrustedStep__has_been_modified_in_an_untrusted_revis(scriptPath));
+                                    listener.annotate(new WarningNote());
+                                    listener.getLogger().println(Messages.ReadTrustedStep__has_been_modified_in_an_untrusted_revis(scriptPath));
+                                    // TODO JENKINS-45970 consider aborting instead, at least optionally
                                 }
                             }
                         }
@@ -159,6 +160,23 @@ class SCMBinder extends FlowDefinition {
                 return context instanceof WorkflowJob && ((WorkflowJob) context).getParent() instanceof WorkflowMultiBranchProject;
             }
             return true;
+        }
+
+    }
+
+    // TODO seems there is no general-purpose ConsoleNote which simply wraps markup in specified HTML
+    @SuppressWarnings("rawtypes")
+    public static class WarningNote extends ConsoleNote {
+
+        @Override public ConsoleAnnotator annotate(Object context, MarkupText text, int charPos) {
+            text.addMarkup(0, text.length(), "<span class='warning-inline'>", "</span>");
+            return null;
+        }
+
+        @Extension public static final class DescriptorImpl extends ConsoleAnnotationDescriptor {
+            @Override public String getDisplayName() {
+                return "Multibranch warnings";
+            }
         }
 
     }

--- a/src/main/java/org/jenkinsci/plugins/workflow/multibranch/SCMBinder.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/multibranch/SCMBinder.java
@@ -61,7 +61,6 @@ class SCMBinder extends FlowDefinition {
 
     /** Kill switch for JENKINS-33273 in case of problems. */
     static /* not final */ boolean USE_HEAVYWEIGHT_CHECKOUT = Boolean.getBoolean(SCMBinder.class.getName() + ".USE_HEAVYWEIGHT_CHECKOUT"); // TODO 2.4+ use SystemProperties
-
     private String scriptPath = WorkflowBranchProjectFactory.SCRIPT;
 
     public Object readResolve() {

--- a/src/test/java/org/jenkinsci/plugins/workflow/multibranch/SCMBinderTest.java
+++ b/src/test/java/org/jenkinsci/plugins/workflow/multibranch/SCMBinderTest.java
@@ -232,8 +232,7 @@ public class SCMBinderTest {
 
     @Test public void untrustedRevisions() throws Exception {
         sampleGitRepo.init();
-        String masterJenkinsfile = "node {checkout scm; echo readFile('file')}";
-        sampleGitRepo.write("Jenkinsfile", masterJenkinsfile);
+        sampleGitRepo.write("Jenkinsfile", "node {checkout scm; echo readFile('file')}");
         sampleGitRepo.write("file", "initial content");
         sampleGitRepo.git("add", "Jenkinsfile");
         sampleGitRepo.git("commit", "--all", "--message=flow");
@@ -258,20 +257,8 @@ public class SCMBinderTest {
         assertNotNull(b);
         assertEquals(1, b.getNumber());
         assertRevisionAction(b);
-        r.assertBuildStatus(Result.FAILURE, b);
+        r.assertBuildStatusSuccess(b);
         r.assertLogContains(Messages.ReadTrustedStep__has_been_modified_in_an_untrusted_revis("Jenkinsfile"), b);
-        r.assertLogContains("not trusting", b);
-        SCMBinder.IGNORE_UNTRUSTED_EDITS = true;
-        try {
-            b = r.buildAndAssertSuccess(p);
-            r.assertLogContains("subsequent content", b);
-            r.assertLogContains("not trusting", b);
-        } finally {
-            SCMBinder.IGNORE_UNTRUSTED_EDITS = false;
-        }
-        sampleGitRepo.write("Jenkinsfile", masterJenkinsfile);
-        sampleGitRepo.git("commit", "--all", "--message=meekly submitting");
-        b = r.buildAndAssertSuccess(p);
         r.assertLogContains("subsequent content", b);
         r.assertLogContains("not trusting", b);
     }


### PR DESCRIPTION
https://github.com/jenkinsci/ssh-slaves-plugin/pull/79 and the like are pretty annoying: the historical behavior of `SCMBinder` is to allow a build which includes an untrusted edit to `Jenkinsfile` to proceed, but actually reading the `Jenkinsfile` contents from the corresponding trusted revision instead. If you get a green check mark, no one is going to go looking for the one-line warning about this. It is better to behave as if the script started with

```groovy
readTrusted 'Jenkinsfile'
```

In other words, to just fail immediately in such a case. I cannot think of any good reason for anyone to be relying on the old behavior, but just in case I kept it as an option which can be enabled by system property.

Note that this change will not have any effect on GitHub PR merge jobs until [JENKINS-43194](https://issues.jenkins-ci.org/browse/JENKINS-43194) is implemented. Performing a rev-to-tip comparison of script contents in a heavyweight checkout would be pretty awkward, as `SCMBinder` could not then rely on `CpsScmFlowDefinition` for script checkout; `ReadTrustedStep` would need to be refactored to make its main logic reusable, and there would be a lot of different code paths to maintain code coverage for. I think the effort is better put into JENKINS-43194.

@reviewbybees