### PR TITLE
Add a configurable option to force heavyweight checkout.

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/workflow/multibranch/SCMBinder.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/multibranch/SCMBinder.java
@@ -59,6 +59,7 @@ class SCMBinder extends FlowDefinition {
     /** Kill switch for JENKINS-33273 in case of problems. */
     static /* not final */ boolean USE_HEAVYWEIGHT_CHECKOUT = Boolean.getBoolean(SCMBinder.class.getName() + ".USE_HEAVYWEIGHT_CHECKOUT"); // TODO 2.4+ use SystemProperties
     private String scriptPath = WorkflowBranchProjectFactory.SCRIPT;
+    private boolean forceHeavyweightCheckout = false;
 
     public Object readResolve() {
         if (this.scriptPath == null) {
@@ -67,8 +68,9 @@ class SCMBinder extends FlowDefinition {
         return this;
     }
 
-    public SCMBinder(String scriptPath) {
+    public SCMBinder(String scriptPath, boolean forceHeavyweightCheckout) {
         this.scriptPath = scriptPath;
+        this.forceHeavyweightCheckout = forceHeavyweightCheckout;
     }
 
     @Override public FlowExecution create(FlowExecutionOwner handle, TaskListener listener, List<? extends Action> actions) throws Exception {
@@ -97,7 +99,7 @@ class SCMBinder extends FlowDefinition {
         if (tip != null) {
             build.addAction(new SCMRevisionAction(scmSource, tip));
             SCMRevision rev = scmSource.getTrustedRevision(tip, listener);
-            try (SCMFileSystem fs = USE_HEAVYWEIGHT_CHECKOUT ? null : SCMFileSystem.of(scmSource, head, rev)) {
+            try (SCMFileSystem fs = (USE_HEAVYWEIGHT_CHECKOUT || forceHeavyweightCheckout) ? null : SCMFileSystem.of(scmSource, head, rev)) {
                 if (fs != null) { // JENKINS-33273
                     String script = null;
                     try {

--- a/src/main/java/org/jenkinsci/plugins/workflow/multibranch/WorkflowBranchProjectFactory.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/multibranch/WorkflowBranchProjectFactory.java
@@ -41,6 +41,7 @@ import org.kohsuke.stapler.DataBoundSetter;
 public class WorkflowBranchProjectFactory extends AbstractWorkflowBranchProjectFactory {
     static final String SCRIPT = "Jenkinsfile";
     private String scriptPath = SCRIPT;
+    private boolean forceHeavyweightCheckout = false;
 
     public Object readResolve() {
         if (this.scriptPath == null) {
@@ -64,8 +65,17 @@ public class WorkflowBranchProjectFactory extends AbstractWorkflowBranchProjectF
         return scriptPath;
     }
 
+    @DataBoundSetter
+    public void setForceHeavyweightCheckout(boolean forceHeavyweightCheckout) {
+        this.forceHeavyweightCheckout = forceHeavyweightCheckout;
+    }
+
+    public boolean getForceHeavyweightCheckout(){
+        return forceHeavyweightCheckout;
+    }
+
     @Override protected FlowDefinition createDefinition() {
-        return new SCMBinder(scriptPath);
+        return new SCMBinder(scriptPath, forceHeavyweightCheckout);
     }
 
     @Override protected SCMSourceCriteria getSCMSourceCriteria(SCMSource source) {

--- a/src/main/resources/org/jenkinsci/plugins/workflow/multibranch/WorkflowBranchProjectFactory/config.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/workflow/multibranch/WorkflowBranchProjectFactory/config.jelly
@@ -28,4 +28,7 @@ THE SOFTWARE.
     <f:entry title="${%Script Path}" field="scriptPath">
         <f:textbox default="Jenkinsfile"/>
     </f:entry>
+    <f:entry title="${%Force heavyweight checkout for Jenkinsfile retrieval}" field="forceHeavyweightCheckout">
+        <f:checkbox />
+    </f:entry>
 </j:jelly>


### PR DESCRIPTION
Hi,

This is an attempt (I am not a Java developer and I hardly know how to set up a Jenkins instance by myself) to try to add a configurable option for the initial checkout of the Jenkinsfile. This is motivated by the problems described in JENKINS-42882 and JENKINS-42830.

In my case, it's even worse than using a symlink, I am using symlink pointing to a git submodule of my project. Using just symlinks alone, or submodule alone (and setting a custom script path) are broken "features" with the lightweight checkout. I understand Jesse Glick writes that symlinks (and I guess most likely submodules as well) are not supported wrt the Jenkinsfile location, yet I wish this could be at least possible through a configurable fallback to heavyweight checkouts for those who want to. Even if it has never been an officially supported feature, it used to work until lightweight checkout was introduced. Both symlinks are submodules are quite common concept that I would expect a tool like Jenkins Pipeline should at least support one way or another.

Also JENKINS-42882 was closed with the argument that now you can configure the path to the Jenkinsfile. I don't find that fully satisfying since:
 - It forces all the branches of the same repository to use the same path, while previously when symlinked worked but were not officially supported, all branches could technically use different paths. When several teams work on the same repository but on different branches, and have different ways of handling their CI, that may not be convenient (I am in such a case).
 - It doesn't fix the issue for people like me who use git submodules to store their Jenkinsfile (and share it across different but similar projects, without falling back to copy/pasting that file everywhere). And again even if unsupported, it used to work.

The global kill switch seems to be a bit too much, we should provide a per project granularity. Is this some kind of workaround you would be ready to accept ?

Cheers,
Romain