### PR TITLE
Fix [JENKINS-50784] by using a blocking load of execution where needed

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/workflow/multibranch/JobPropertyStep.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/multibranch/JobPropertyStep.java
@@ -101,7 +101,7 @@ public class JobPropertyStep extends AbstractStepImpl {
                     FlowExecutionOwner owner = ((FlowExecutionOwner.Executable) previousRun).asFlowExecutionOwner();
 
                     if (owner != null) {
-                        FlowExecution execution = owner.getOrNull();
+                        FlowExecution execution = owner.get();
                         if (execution != null) {
                             previousHadStep = new DepthFirstScanner().findFirstMatch(execution,
                                     new NodeStepTypePredicate(step.getDescriptor())) != null;


### PR DESCRIPTION
[JENKINS-50784](https://issues.jenkins-ci.org/browse/JENKINS-50784) - will fix minor regressions in cases where the execution of the previous build is not lazy-loaded c.f. https://github.com/jenkinsci/workflow-job-plugin/pull/93