### PR TITLE
Test and fix for [JENKINS-51290] - properties step fails with error about job not yet started if could not obtain execution for previous run

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -70,7 +70,7 @@ THE SOFTWARE.
         <workflow-step-api.version>2.13</workflow-step-api.version>
         <workflow-scm-step-plugin.version>2.4</workflow-scm-step-plugin.version>
         <workflow-support.version>2.17</workflow-support.version>
-        <workflow-cps.version>2.43</workflow-cps.version>
+        <workflow-cps.version>2.53</workflow-cps.version>
         <git-plugin.version>3.7.0</git-plugin.version>
     </properties>
     <dependencies>
@@ -82,7 +82,7 @@ THE SOFTWARE.
         <dependency>
             <groupId>org.jenkins-ci.plugins.workflow</groupId>
             <artifactId>workflow-job</artifactId>
-            <version>2.20</version>
+            <version>2.21</version>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins.workflow</groupId>
@@ -92,7 +92,7 @@ THE SOFTWARE.
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>structs</artifactId>
-            <version>1.10</version>
+            <version>1.14</version>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins.workflow</groupId>
@@ -123,7 +123,7 @@ THE SOFTWARE.
         <dependency>
             <groupId>org.jenkins-ci.plugins.workflow</groupId>
             <artifactId>workflow-api</artifactId>
-            <version>2.25</version>
+            <version>2.27</version>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins.workflow</groupId>
@@ -133,7 +133,7 @@ THE SOFTWARE.
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>script-security</artifactId>
-            <version>1.39</version>
+            <version>1.42</version>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>

--- a/src/main/java/org/jenkinsci/plugins/workflow/multibranch/JobPropertyStep.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/multibranch/JobPropertyStep.java
@@ -35,6 +35,8 @@ import hudson.model.Job;
 import hudson.model.JobProperty;
 import hudson.model.JobPropertyDescriptor;
 import hudson.model.Run;
+
+import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
@@ -113,9 +115,9 @@ public class JobPropertyStep extends AbstractStepImpl {
                                 previousHadStep = new DepthFirstScanner().findFirstMatch(execution,
                                         new NodeStepTypePredicate(step.getDescriptor())) != null;
                             }
-                        } catch (Exception ex) {
+                        } catch (IOException ex) {
                             // May happen legitimately due to owner.get() throwing IOException when previous execution was nulled
-                            LOGGER.log(Level.FINE, "Could not search for JobPropertyStep execution: previous run either had null execution due to legitimate error and shows as not-yet-started, or threw exception", ex);
+                            LOGGER.log(Level.FINE, "Could not search for JobPropertyStep execution: previous run either had null execution due to legitimate error and shows as not-yet-started, or threw other IOException", ex);
                         }
                     }
                 }

--- a/src/test/java/org/jenkinsci/plugins/workflow/multibranch/JobPropertyStepTest.java
+++ b/src/test/java/org/jenkinsci/plugins/workflow/multibranch/JobPropertyStepTest.java
@@ -145,7 +145,8 @@ public class JobPropertyStepTest {
     public void testPreviousBuildFailedHard() throws Exception {
         WorkflowJob p = r.jenkins.createProject(WorkflowJob.class, "p");
 
-        // First we simulate a build that has failed so hard it has a null execution
+        // First we simulate a build that has resulted in a null execution
+        // This can be a result of a hard-kill of the Pipeline or a catastrophic failure starting the run, i.e. fetching the Jenkinsfile
         p.setDefinition(new CpsFlowDefinition("echo 'Not doing anything'", true));
         WorkflowRun run = r.buildAndAssertSuccess(p);
         Field f = run.getClass().getDeclaredField("execution");

--- a/src/test/java/org/jenkinsci/plugins/workflow/multibranch/JobPropertyStepTest.java
+++ b/src/test/java/org/jenkinsci/plugins/workflow/multibranch/JobPropertyStepTest.java
@@ -35,6 +35,7 @@ import hudson.model.StringParameterValue;
 import hudson.model.queue.QueueTaskFuture;
 import hudson.tasks.LogRotator;
 
+import java.lang.reflect.Field;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -77,6 +78,7 @@ import static org.hamcrest.core.StringContains.containsString;
 import static org.junit.Assert.*;
 
 import org.junit.After;
+import org.junit.Assert;
 import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
@@ -136,6 +138,24 @@ public class JobPropertyStepTest {
         List<JobProperty> emptyInput = tester.configRoundTrip(new JobPropertyStep(Collections.<JobProperty>emptyList())).getProperties();
 
         assertEquals(Collections.emptyList(), removeTriggerProperty(emptyInput));
+    }
+
+    @Issue("JENKINS-51290")
+    @Test
+    public void testPreviousBuildFailedHard() throws Exception {
+        WorkflowJob p = r.jenkins.createProject(WorkflowJob.class, "p");
+
+        // First we simulate a build that has failed so hard it has a null execution
+        p.setDefinition(new CpsFlowDefinition("echo 'Not doing anything'", true));
+        WorkflowRun run = r.buildAndAssertSuccess(p);
+        Field f = run.getClass().getDeclaredField("execution");
+        f.setAccessible(true);
+        f.set(run, null);
+        Assert.assertNull(run.getExecution());
+
+        // Verify build runs cleanly
+        p.setDefinition(new CpsFlowDefinition("properties([[$class: 'BuildDiscarderProperty', strategy: [$class: 'LogRotator', numToKeepStr: '1']]])", true));
+        r.buildAndAssertSuccess(p);
     }
 
     @SuppressWarnings("rawtypes")


### PR DESCRIPTION
... unfortunately we may legitimately null the execution for certain critical failures.

[https://issues.jenkins-ci.org/browse/JENKINS-51290](https://issues.jenkins-ci.org/browse/JENKINS-51290)

@reviewbybees 

Note: A *better* fix would be to add a new API to `FlowExecutionOwner` that can trigger lazy loading and behaves like either `FlowExcecutionOwner#get()` or `FlowExcecutionOwner#getOrNull()` but this issue is fairly critical so we need at least a fast solution. 