### PR TITLE
Update unit tests for compatibility with git-plugin >=3.9.x

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -71,7 +71,7 @@ THE SOFTWARE.
         <workflow-scm-step-plugin.version>2.4</workflow-scm-step-plugin.version>
         <workflow-support.version>2.17</workflow-support.version>
         <workflow-cps.version>2.53</workflow-cps.version>
-        <git-plugin.version>3.7.0</git-plugin.version>
+        <git-plugin.version>3.9.1</git-plugin.version>
     </properties>
     <dependencies>
         <dependency>
@@ -197,7 +197,7 @@ THE SOFTWARE.
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>git</artifactId>
-            <version>3.9.1</version>
+            <version>${git-plugin.version}</version>
             <scope>test</scope>
             <exclusions>
                 <exclusion>

--- a/pom.xml
+++ b/pom.xml
@@ -197,7 +197,7 @@ THE SOFTWARE.
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>git</artifactId>
-            <version>${git-plugin.version}</version>
+            <version>3.9.1</version>
             <scope>test</scope>
             <exclusions>
                 <exclusion>

--- a/src/test/java/org/jenkinsci/plugins/workflow/multibranch/JobPropertyStepTest.java
+++ b/src/test/java/org/jenkinsci/plugins/workflow/multibranch/JobPropertyStepTest.java
@@ -51,6 +51,7 @@ import jenkins.branch.OverrideIndexTriggersJobProperty;
 import jenkins.model.BuildDiscarder;
 import jenkins.model.BuildDiscarderProperty;
 import jenkins.plugins.git.GitSCMSource;
+import jenkins.plugins.git.GitBranchSCMHead;
 import jenkins.plugins.git.GitSampleRepoRule;
 import jenkins.triggers.ReverseBuildTrigger;
 import org.jenkinsci.Symbol;
@@ -641,7 +642,7 @@ public class JobPropertyStepTest {
             assertEquals(mp, source.getOwner());
         }
         WorkflowJob p = scheduleAndFindBranchProject(mp, "master");
-        assertEquals(new SCMHead("master"), SCMHead.HeadByItem.findHead(p));
+        assertEquals(new GitBranchSCMHead("master"), SCMHead.HeadByItem.findHead(p));
         assertEquals(1, mp.getItems().size());
         r.waitUntilNoActivity();
         WorkflowRun b1 = p.getLastBuild();

--- a/src/test/java/org/jenkinsci/plugins/workflow/multibranch/SCMBinderTest.java
+++ b/src/test/java/org/jenkinsci/plugins/workflow/multibranch/SCMBinderTest.java
@@ -41,7 +41,7 @@ import java.util.Set;
 import java.util.TreeSet;
 import jenkins.branch.BranchSource;
 import jenkins.model.Jenkins;
-import jenkins.plugins.git.AbstractGitSCMSource;
+import jenkins.plugins.git.GitBranchSCMRevision;
 import jenkins.plugins.git.GitSCMSource;
 import jenkins.plugins.git.GitSampleRepoRule;
 import jenkins.scm.api.SCMHead;
@@ -118,14 +118,14 @@ public class SCMBinderTest {
         SCMRevisionAction revisionAction = build.getAction(SCMRevisionAction.class);
         assertNotNull(revisionAction);
         SCMRevision revision = revisionAction.getRevision();
-        assertEquals(AbstractGitSCMSource.SCMRevisionImpl.class, revision.getClass());
+        assertEquals(GitBranchSCMRevision.class, revision.getClass());
         Set<String> expected = new HashSet<>();
         List<BuildData> buildDataActions = build.getActions(BuildData.class);
         if (!buildDataActions.isEmpty()) { // i.e., we have run at least one checkout step, or done a heavyweight checkout to get a single file
             for (BuildData data : buildDataActions) {
                 expected.add(data.lastBuild.marked.getSha1().getName());
             }
-            assertThat(expected, hasItem(((AbstractGitSCMSource.SCMRevisionImpl) revision).getHash()));
+            assertThat(expected, hasItem(((GitBranchSCMRevision) revision).getHash()));
         }
     }
 

--- a/src/test/java/org/jenkinsci/plugins/workflow/multibranch/WorkflowMultiBranchProjectTest.java
+++ b/src/test/java/org/jenkinsci/plugins/workflow/multibranch/WorkflowMultiBranchProjectTest.java
@@ -53,6 +53,7 @@ import jenkins.branch.NoTriggerBranchProperty;
 import jenkins.branch.RateLimitBranchProperty;
 import jenkins.branch.UntrustedBranchProperty;
 import jenkins.plugins.git.GitSCMSource;
+import jenkins.plugins.git.GitBranchSCMHead;
 import jenkins.plugins.git.GitSampleRepoRule;
 import jenkins.scm.api.SCMHead;
 import jenkins.scm.api.SCMSource;
@@ -87,7 +88,7 @@ public class WorkflowMultiBranchProjectTest {
             assertEquals(mp, source.getOwner());
         }
         WorkflowJob p = scheduleAndFindBranchProject(mp, "master");
-        assertEquals(new SCMHead("master"), SCMHead.HeadByItem.findHead(p));
+        assertEquals(new GitBranchSCMHead("master"), SCMHead.HeadByItem.findHead(p));
         assertEquals(1, mp.getItems().size());
         r.waitUntilNoActivity();
         WorkflowRun b1 = p.getLastBuild();


### PR DESCRIPTION
# Description

This pull request updates unit tests in workflow-multibranch so that they are compatible with versions of git-plugin >=3.9.0. These changes to git-plugin went in with [PR 577](https://github.com/jenkinsci/git-plugin/pull/577). As such, there is now a test-scope maven dependency for git-plugin 3.9.1. `git-plugin.version` has been left at 3.7.0.

@svanoort and @rsandell , your reviews would be appreciated. Thanks!