### PR TITLE
Making the BranchJobProperty constructor public

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/workflow/multibranch/BranchJobProperty.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/multibranch/BranchJobProperty.java
@@ -47,7 +47,7 @@ public class BranchJobProperty extends WorkflowJobProperty {
 
     private @Nonnull Branch branch;
 
-    BranchJobProperty(@Nonnull Branch branch) {
+    public BranchJobProperty(@Nonnull Branch branch) {
         this.branch = branch;
     }
 


### PR DESCRIPTION
I would appreciate if you make this public, 
I am working on a different plugin which provides a different kind of project recognizer, I appreciate if this class can be instantiated outside of your package.