### PR TITLE
Added public modifier to SCMBinder class

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/workflow/multibranch/SCMBinder.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/multibranch/SCMBinder.java
@@ -54,7 +54,7 @@ import org.jenkinsci.plugins.workflow.job.WorkflowRun;
 /**
  * Checks out the desired version of the script referred to by scriptPath.
  */
-class SCMBinder extends FlowDefinition {
+public class SCMBinder extends FlowDefinition {
 
     /** Kill switch for JENKINS-33273 in case of problems. */
     static /* not final */ boolean USE_HEAVYWEIGHT_CHECKOUT = Boolean.getBoolean(SCMBinder.class.getName() + ".USE_HEAVYWEIGHT_CHECKOUT"); // TODO 2.4+ use SystemProperties


### PR DESCRIPTION
I am developing a plugin and I would like to identify jobs by their FlowDefinition types. I need SCMBinder to be public for this purpose.