### PR TITLE
Consistently use sandbox for CpsFlowDefinitions

### DIFF
--- a/src/test/java/org/jenkinsci/plugins/workflow/multibranch/JobPropertyStepTest.java
+++ b/src/test/java/org/jenkinsci/plugins/workflow/multibranch/JobPropertyStepTest.java
@@ -327,7 +327,7 @@ public class JobPropertyStepTest {
     @Test public void concurrentBuildProperty() throws Exception {
         WorkflowJob p = r.jenkins.createProject(WorkflowJob.class, "p");
         // Verify the base case behavior.
-        p.setDefinition(new CpsFlowDefinition("semaphore 'hang'"));
+        p.setDefinition(new CpsFlowDefinition("semaphore 'hang'", true));
 
         assertTrue(p.isConcurrentBuild());
 
@@ -346,7 +346,7 @@ public class JobPropertyStepTest {
 
         // Verify that the property successfully disables concurrent builds.
         p.setDefinition(new CpsFlowDefinition("properties([disableConcurrentBuilds()])\n"
-                + "semaphore 'hang'"));
+                + "semaphore 'hang'", true));
 
         assertTrue(p.isConcurrentBuild());
 
@@ -372,7 +372,7 @@ public class JobPropertyStepTest {
     @Test public void triggersProperty() throws Exception {
         WorkflowJob p = r.jenkins.createProject(WorkflowJob.class, "p");
         // Verify the base case behavior.
-        p.setDefinition(new CpsFlowDefinition("echo 'foo'"));
+        p.setDefinition(new CpsFlowDefinition("echo 'foo'", true));
 
         assertTrue(p.getTriggers().isEmpty());
 
@@ -384,7 +384,8 @@ public class JobPropertyStepTest {
         // Now add a trigger.
         p.setDefinition(new CpsFlowDefinition(
                 "properties([pipelineTriggers([\n"
-              + "  cron('@daily'), [$class: 'MockTrigger']])])\n" + "echo 'foo'"));
+              + "  cron('@daily'), [$class: 'MockTrigger']])])\n" + "echo 'foo'",
+                true));
 
         WorkflowRun b = r.assertBuildStatusSuccess(p.scheduleBuild2(0));
 
@@ -409,7 +410,7 @@ public class JobPropertyStepTest {
         // Now run a properties step with a different property and verify that we still have a
         // PipelineTriggersJobProperty, but with no triggers in it.
         p.setDefinition(new CpsFlowDefinition("properties([disableConcurrentBuilds()])\n"
-                + "echo 'foo'"));
+                + "echo 'foo'", true));
 
         WorkflowRun b2 = r.assertBuildStatusSuccess(p.scheduleBuild2(0));
 
@@ -424,7 +425,7 @@ public class JobPropertyStepTest {
     @Test public void scmTriggerProperty() throws Exception {
         WorkflowJob p = r.jenkins.createProject(WorkflowJob.class, "p");
         // Verify the base case behavior.
-        p.setDefinition(new CpsFlowDefinition("echo 'foo'"));
+        p.setDefinition(new CpsFlowDefinition("echo 'foo'", true));
 
         assertTrue(p.getTriggers().isEmpty());
 
@@ -471,7 +472,7 @@ public class JobPropertyStepTest {
         // Now run a properties step with a different property and verify that we still have a
         // PipelineTriggersJobProperty, but with no triggers in it.
         p.setDefinition(new CpsFlowDefinition("properties([disableConcurrentBuilds()])\n"
-                + "echo 'foo'"));
+                + "echo 'foo'", true));
 
         WorkflowRun b2 = r.assertBuildStatusSuccess(p.scheduleBuild2(0));
 
@@ -485,7 +486,7 @@ public class JobPropertyStepTest {
     @Test public void scmAndEmptyTriggersProperty() throws Exception {
         WorkflowJob p = r.jenkins.createProject(WorkflowJob.class, "p");
         // Verify the base case behavior.
-        p.setDefinition(new CpsFlowDefinition("echo 'foo'"));
+        p.setDefinition(new CpsFlowDefinition("echo 'foo'", true));
 
         assertTrue(p.getTriggers().isEmpty());
 
@@ -514,7 +515,7 @@ public class JobPropertyStepTest {
         // Now run a properties step with an empty triggers property and verify that we still have a
         // PipelineTriggersJobProperty, but with no triggers in it.
         p.setDefinition(new CpsFlowDefinition("properties([pipelineTriggers()])\n"
-                + "echo 'foo'"));
+                + "echo 'foo'", true));
 
         WorkflowRun b2 = r.assertBuildStatusSuccess(p.scheduleBuild2(0));
 

--- a/src/test/java/org/jenkinsci/plugins/workflow/multibranch/ResolveScmStepTest.java
+++ b/src/test/java/org/jenkinsci/plugins/workflow/multibranch/ResolveScmStepTest.java
@@ -61,7 +61,7 @@ public class ResolveScmStepTest {
                     + "targets:['foo']\n"
                     + "  checkout tests\n"
                     + "  if (!fileExists('new-file.txt')) { error 'wrong branch checked out' }\n"
-                    + "}"));
+                    + "}", true));
             j.buildAndAssertSuccess(job);
         } finally {
             c.close();
@@ -81,7 +81,7 @@ public class ResolveScmStepTest {
                     + "', repository:'repo', traits: [discoverBranches()]), "
                     + "targets:['bar'], ignoreErrors: true\n"
                     + "  if (tests != null) { error \"resolved as ${tests}\"}\n"
-                    + "}"));
+                    + "}", true));
             j.buildAndAssertSuccess(job);
         } finally {
             c.close();
@@ -105,7 +105,7 @@ public class ResolveScmStepTest {
                     + "    ok = false\n"
                     + "  } catch (e) {}\n"
                     + "  if (!ok) { error 'abort not thrown' }\n"
-                    + "}"));
+                    + "}", true));
             j.buildAndAssertSuccess(job);
         } finally {
             c.close();
@@ -127,7 +127,7 @@ public class ResolveScmStepTest {
                     + "targets:['bar', 'manchu']\n"
                     + "  checkout tests\n"
                     + "  if (!fileExists('new-file.txt')) { error 'wrong branch checked out' }\n"
-                    + "}"));
+                    + "}", true));
             j.buildAndAssertSuccess(job);
         } finally {
             c.close();


### PR DESCRIPTION
While looking at the test suite for this plugin, I noticed the `CpsFlowDefinition`s in the tests don't consistently use the script security sandbox. Using the script security sandbox results in a more realistic environment given that the script security sandbox should always be enabled in production.

In this change, I replaced any usages of the deprecated single-argument constructor for `CpsFlowDefinition` with usages of the non-deprecated two-argument constructor, passing in `true` as the second argument in order to always enable the script security sandbox.

Note that I did _not_ touch `ReplayActionTest#multibranch`, which _intentionally_ disables the script security sandbox for testing purposes.