### PR TITLE
Remove usages of deprecated APIs

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/workflow/multibranch/JobPropertyStep.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/multibranch/JobPropertyStep.java
@@ -196,7 +196,7 @@ public class JobPropertyStep extends AbstractStepImpl {
                     } catch (ClassNotFoundException x) {
                         throw new FormException(x, "propertiesMap");
                     }
-                    JobPropertyDescriptor d = (JobPropertyDescriptor) Jenkins.getActiveInstance().getDescriptorOrDie(itemType);
+                    JobPropertyDescriptor d = (JobPropertyDescriptor) Jenkins.get().getDescriptorOrDie(itemType);
                     JSONObject more = (JSONObject) e.getValue();
                     JobProperty property = d.newInstance(req, more);
                     if (property != null) {

--- a/src/main/java/org/jenkinsci/plugins/workflow/multibranch/ReadTrustedStep.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/multibranch/ReadTrustedStep.java
@@ -116,11 +116,11 @@ public class ReadTrustedStep extends AbstractStepImpl {
                 }
                 if (!ok) { // wrong definition or job type
                     throw new AbortException("‘readTrusted’ is only available when using “" +
-                        Jenkins.getActiveInstance().getDescriptorByType(WorkflowMultiBranchProject.DescriptorImpl.class).getDisplayName() +
-                        "” or “" + Jenkins.getActiveInstance().getDescriptorByType(CpsScmFlowDefinition.DescriptorImpl.class).getDisplayName() + "”");
+                        Jenkins.get().getDescriptorByType(WorkflowMultiBranchProject.DescriptorImpl.class).getDisplayName() +
+                        "” or “" + Jenkins.get().getDescriptorByType(CpsScmFlowDefinition.DescriptorImpl.class).getDisplayName() + "”");
                 }
             }
-            Node node = Jenkins.getActiveInstance();
+            Node node = Jenkins.get();
             FilePath dir;
             if (job instanceof TopLevelItem) {
                 FilePath baseWorkspace = node.getWorkspaceFor((TopLevelItem) job);

--- a/src/main/java/org/jenkinsci/plugins/workflow/multibranch/SCMVar.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/multibranch/SCMVar.java
@@ -78,8 +78,8 @@ import org.jenkinsci.plugins.workflow.support.pickles.XStreamPickle;
                 }
             }
             throw new AbortException("‘checkout scm’ is only available when using “" +
-                Jenkins.getActiveInstance().getDescriptorByType(WorkflowMultiBranchProject.DescriptorImpl.class).getDisplayName() +
-                "” or “" + Jenkins.getActiveInstance().getDescriptorByType(CpsScmFlowDefinition.DescriptorImpl.class).getDisplayName() + "”");
+                Jenkins.get().getDescriptorByType(WorkflowMultiBranchProject.DescriptorImpl.class).getDisplayName() +
+                "” or “" + Jenkins.get().getDescriptorByType(CpsScmFlowDefinition.DescriptorImpl.class).getDisplayName() + "”");
         }
         Branch branch = property.getBranch();
         ItemGroup<?> parent = job.getParent();

--- a/src/test/java/org/jenkinsci/plugins/workflow/multibranch/ReplayActionTest.java
+++ b/src/test/java/org/jenkinsci/plugins/workflow/multibranch/ReplayActionTest.java
@@ -149,7 +149,7 @@ public class ReplayActionTest {
     }
     private static boolean canReplay(WorkflowRun b, String user) {
         final ReplayAction a = b.getAction(ReplayAction.class);
-        return ACL.impersonate(User.get(user).impersonate(), new NotReallyRoleSensitiveCallable<Boolean,RuntimeException>() {
+        return ACL.impersonate(User.getById(user, true).impersonate(), new NotReallyRoleSensitiveCallable<Boolean,RuntimeException>() {
             @Override public Boolean call() throws RuntimeException {
                 return a.isEnabled();
             }

--- a/src/test/java/org/jenkinsci/plugins/workflow/multibranch/ReplayActionTest.java
+++ b/src/test/java/org/jenkinsci/plugins/workflow/multibranch/ReplayActionTest.java
@@ -27,6 +27,7 @@ package org.jenkinsci.plugins.workflow.multibranch;
 import hudson.model.Item;
 import hudson.model.User;
 import hudson.security.ACL;
+import hudson.security.ACLContext;
 import java.io.File;
 import java.util.Collections;
 import jenkins.branch.BranchProperty;
@@ -149,11 +150,9 @@ public class ReplayActionTest {
     }
     private static boolean canReplay(WorkflowRun b, String user) {
         final ReplayAction a = b.getAction(ReplayAction.class);
-        return ACL.impersonate(User.getById(user, true).impersonate(), new NotReallyRoleSensitiveCallable<Boolean,RuntimeException>() {
-            @Override public Boolean call() throws RuntimeException {
-                return a.isEnabled();
-            }
-        });
+        try (ACLContext context = ACL.as(User.getById(user, true))) {
+            return a.isEnabled();
+        }
     }
 
 }

--- a/src/test/java/org/jenkinsci/plugins/workflow/multibranch/SCMBinderTest.java
+++ b/src/test/java/org/jenkinsci/plugins/workflow/multibranch/SCMBinderTest.java
@@ -207,7 +207,7 @@ public class SCMBinderTest {
         r.waitUntilNoActivity();
         WorkflowRun b1 = p.getLastBuild();
         assertEquals(1, b1.getNumber());
-        Authentication auth = User.get("dev").impersonate();
+        Authentication auth = User.getById("dev", true).impersonate();
         assertFalse(p.getACL().hasPermission(auth, Item.DELETE));
         assertTrue(p.isBuildable());
         sampleGitRepo.git("checkout", "master");

--- a/src/test/java/org/jenkinsci/plugins/workflow/multibranch/SCMBinderTest.java
+++ b/src/test/java/org/jenkinsci/plugins/workflow/multibranch/SCMBinderTest.java
@@ -276,7 +276,7 @@ public class SCMBinderTest {
             }
         }
         @Override public SCMSourceDescriptor getDescriptor() {
-            return Jenkins.getInstance().getDescriptorByType(GitSCMSource.DescriptorImpl.class);
+            return Jenkins.get().getDescriptorByType(GitSCMSource.DescriptorImpl.class);
         }
     }
 

--- a/src/test/java/org/jenkinsci/plugins/workflow/multibranch/WorkflowMultiBranchProjectFactoryTest.java
+++ b/src/test/java/org/jenkinsci/plugins/workflow/multibranch/WorkflowMultiBranchProjectFactoryTest.java
@@ -81,7 +81,7 @@ public class WorkflowMultiBranchProjectFactoryTest {
         assertEquals(1, sources.size());
         assertEquals("GitSCMSource", sources.get(0).getClass().getSimpleName());
         // Verify permissions:
-        Authentication admin = User.get("admin").impersonate();
+        Authentication admin = User.getById("admin", true).impersonate();
         ACL acl = one.getACL();
         assertTrue(acl.hasPermission(ACL.SYSTEM, Item.CONFIGURE));
         assertTrue(acl.hasPermission(ACL.SYSTEM, Item.DELETE));


### PR DESCRIPTION
While perusing the source tree, I noticed a number of deprecated methods:

- The documentation for [`ACL.impersonate(org.acegisecurity.Authentication, java.lang.Runnable)`](https://javadoc.jenkins-ci.org/hudson/security/ACL.html#impersonate-org.acegisecurity.Authentication-java.lang.Runnable-) states: "use try with resources and [`as(Authentication)`](https://javadoc.jenkins-ci.org/hudson/security/ACL.html#as-org.acegisecurity.Authentication-)".
- The documentation for [`User.get(java.lang.String)`](https://javadoc.jenkins-ci.org/hudson/model/User.html#get-java.lang.String-) states: "This method is deprecated, because it causes unexpected `User` creation by API usage code and causes performance degradation of used to retrieve users by ID. Use [`getById(java.lang.String, boolean)`](https://javadoc.jenkins-ci.org/hudson/model/User.html#getById-java.lang.String-boolean-) when you know you have an ID."
- The documentation for [`Jenkins.getActiveInstance()`](https://javadoc.jenkins-ci.org/jenkins/model/Jenkins.html#getActiveInstance--) states: "This is a verbose historical alias for [`get()`](https://javadoc.jenkins-ci.org/jenkins/model/Jenkins.html#get--)."
- The documentation for [`Jenkins.getInstance()`](https://javadoc.jenkins-ci.org/jenkins/model/Jenkins.html#getInstance--) states: "This is a historical alias for [`getInstanceOrNull()`](https://javadoc.jenkins-ci.org/jenkins/model/Jenkins.html#getInstanceOrNull--) but with ambiguous nullability. Use [`get()`](https://javadoc.jenkins-ci.org/jenkins/model/Jenkins.html#get--) in typical cases."

Accordingly, I replaced any calls to `User.get(java.lang.String` with calls to `User.getById(java.lang.String, boolean`, I replaced any usages of `ACL.impersonate` with usages of try-with-resources and `ACL.as`, and I replaced any calls to `Jenkins.getActiveInstance()` with calls to `Jenkins.get()`.

There is only one call to `Jenkins.getInstance()`, and we always call `getDescriptorByType()` on the result, so the code assumes that the result is non-null. Therefore `Jenkins.get()` is more appropriate to use here rather than `Jenkins.getInstanceOrNull()`. So I changed the code to use `Jenkins.get()`.