### PR TITLE
Upgrade workflow-scm-step past 2.6

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -70,7 +70,6 @@ THE SOFTWARE.
         <scm-api.version>2.2.7</scm-api.version>
         <no-test-jar>false</no-test-jar>
         <workflow-step-api.version>2.13</workflow-step-api.version>
-        <workflow-scm-step-plugin.version>2.4</workflow-scm-step-plugin.version>
         <workflow-support.version>2.17</workflow-support.version>
         <workflow-cps.version>2.53</workflow-cps.version>
         <git-plugin.version>3.9.1</git-plugin.version>
@@ -124,7 +123,7 @@ THE SOFTWARE.
         <dependency>
             <groupId>org.jenkins-ci.plugins.workflow</groupId>
             <artifactId>workflow-scm-step</artifactId>
-            <version>${workflow-scm-step-plugin.version}</version>
+            <version>2.7</version>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
@@ -180,13 +179,6 @@ THE SOFTWARE.
             <groupId>org.jenkins-ci.plugins.workflow</groupId>
             <artifactId>workflow-cps</artifactId>
             <version>${workflow-cps.version}</version>
-            <classifier>tests</classifier>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.jenkins-ci.plugins.workflow</groupId>
-            <artifactId>workflow-scm-step</artifactId>
-            <version>${workflow-scm-step-plugin.version}</version>
             <classifier>tests</classifier>
             <scope>test</scope>
         </dependency>


### PR DESCRIPTION
### Problem

Observed in jenkinsci/bom#53 when attempting to add `workflow-multibranch` to the  managed set. Running the Plugin Compatibility Tester against `workflow-multibranch` plugin and a newer version of `workflow-scm-step`, the following error appears:

> Failed to execute goal on project workflow-multibranch: Could not resolve dependencies for project org.jenkins-ci.plugins.workflow:workflow-multibranch:hpi:2.21: Could not find artifact org.jenkins-ci.plugins.workflow:workflow-scm-step:jar:tests:2.9 in repo.jenkins-ci.org (https://repo.jenkins-ci.org/public/) -> [Help 1]

### Evaluation

I saw that between `workflow-scm-step` [2.6](https://repo.jenkins-ci.org/releases/org/jenkins-ci/plugins/workflow/workflow-scm-step/2.6/) and [2.7](https://repo.jenkins-ci.org/releases/org/jenkins-ci/plugins/workflow/workflow-scm-step/2.7/) a `tests`-classified JAR was removed, yet `workflow-multibranch` [still depends on it](https://github.com/jenkinsci/workflow-multibranch-plugin/blob/b7bc7743259e84e96b355ad9ff814a74a657c189/pom.xml#L134-L140).

### Solution

`workflow-scm-step-2.6-tests.jar` contains nothing other than the `SCMStepTest` class, and `workflow-multibranch` doesn't reference that class. The solution then is to remove the dependency on `workflow-scm-step-2.6-tests.jar` from `workflow-multibranch`, allowing us to bump `workflow-scm-step` past 2.6 from `workflow-multibranch`'s POM.

### Implementation

In this change I bump `workflow-scm-step` from 2.6 to 2.7 in `workflow-multibranch`'s POM to cross this [flag day](https://en.wikipedia.org/wiki/Flag_day_(computing)).