### PR TITLE
Bump parent pom to 3.54 [v2]

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -28,7 +28,7 @@ THE SOFTWARE.
     <parent>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>plugin</artifactId>
-        <version>3.25</version>
+        <version>3.54</version>
         <relativePath />
     </parent>
     <groupId>org.jenkins-ci.plugins.workflow</groupId>
@@ -66,7 +66,7 @@ THE SOFTWARE.
         <revision>2.22</revision>
         <changelist>-SNAPSHOT</changelist>
         <java.level>8</java.level>
-        <jenkins.version>2.121.1</jenkins.version>
+        <jenkins.version>2.138.4</jenkins.version>
         <scm-api.version>2.2.7</scm-api.version>
         <no-test-jar>false</no-test-jar>
         <workflow-step-api.version>2.13</workflow-step-api.version>

--- a/pom.xml
+++ b/pom.xml
@@ -67,12 +67,13 @@ THE SOFTWARE.
         <changelist>-SNAPSHOT</changelist>
         <java.level>8</java.level>
         <jenkins.version>2.138.4</jenkins.version>
-        <scm-api.version>2.2.7</scm-api.version>
+        <scm-api.version>2.6.3</scm-api.version>
         <no-test-jar>false</no-test-jar>
         <workflow-step-api.version>2.13</workflow-step-api.version>
         <workflow-support.version>2.17</workflow-support.version>
         <workflow-cps.version>2.53</workflow-cps.version>
         <git-plugin.version>3.9.1</git-plugin.version>
+        <subversion-plugin.version>2.13.0</subversion-plugin.version>
     </properties>
     <dependencies>
         <dependency>
@@ -201,7 +202,7 @@ THE SOFTWARE.
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>subversion</artifactId>
-            <version>2.7.1</version>
+            <version>${subversion-plugin.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>
@@ -224,7 +225,7 @@ THE SOFTWARE.
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>subversion</artifactId>
-            <version>2.7.1</version>
+            <version>${subversion-plugin.version}</version>
             <classifier>tests</classifier>
             <scope>test</scope>
         </dependency>
@@ -256,7 +257,7 @@ THE SOFTWARE.
         <dependency>
             <groupId>org.jenkins-ci.modules</groupId>
             <artifactId>instance-identity</artifactId>
-            <version>2.1</version>
+            <version>2.2</version>
             <scope>test</scope>
         </dependency>
         <dependency>
@@ -268,7 +269,7 @@ THE SOFTWARE.
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>credentials</artifactId>
-            <version>2.1.14</version>
+            <version>2.1.16</version>
             <scope>test</scope>
         </dependency>
         <dependency>


### PR DESCRIPTION
This PR is a v2 of #90. It bumps subversion-plugin to 2.13.0 instead of adding a workaround for jenkinsci/subversion-plugin#240