### PR TITLE
Updates

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -232,7 +232,7 @@ THE SOFTWARE.
         <dependency>
             <groupId>org.tmatesoft.svnkit</groupId>
             <artifactId>svnkit-cli</artifactId>
-            <version>1.8.14</version>
+            <version>1.10.1</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -28,7 +28,7 @@ THE SOFTWARE.
     <parent>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>plugin</artifactId>
-        <version>3.25</version>
+        <version>3.54</version>
         <relativePath />
     </parent>
     <groupId>org.jenkins-ci.plugins.workflow</groupId>
@@ -66,13 +66,14 @@ THE SOFTWARE.
         <revision>2.22</revision>
         <changelist>-SNAPSHOT</changelist>
         <java.level>8</java.level>
-        <jenkins.version>2.121.1</jenkins.version>
-        <scm-api.version>2.2.7</scm-api.version>
+        <jenkins.version>2.138.4</jenkins.version>
+        <scm-api.version>2.6.3</scm-api.version>
         <no-test-jar>false</no-test-jar>
         <workflow-step-api.version>2.13</workflow-step-api.version>
         <workflow-support.version>2.17</workflow-support.version>
         <workflow-cps.version>2.53</workflow-cps.version>
         <git-plugin.version>3.9.1</git-plugin.version>
+        <subversion-plugin.version>2.13.0</subversion-plugin.version>
     </properties>
     <dependencies>
         <dependency>
@@ -201,7 +202,7 @@ THE SOFTWARE.
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>subversion</artifactId>
-            <version>2.7.1</version>
+            <version>${subversion-plugin.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>
@@ -224,7 +225,7 @@ THE SOFTWARE.
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>subversion</artifactId>
-            <version>2.7.1</version>
+            <version>${subversion-plugin.version}</version>
             <classifier>tests</classifier>
             <scope>test</scope>
         </dependency>
@@ -256,7 +257,7 @@ THE SOFTWARE.
         <dependency>
             <groupId>org.jenkins-ci.modules</groupId>
             <artifactId>instance-identity</artifactId>
-            <version>2.1</version>
+            <version>2.2</version>
             <scope>test</scope>
         </dependency>
         <dependency>
@@ -268,7 +269,7 @@ THE SOFTWARE.
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>credentials</artifactId>
-            <version>2.1.14</version>
+            <version>2.1.16</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/src/test/java/org/jenkinsci/plugins/workflow/multibranch/SCMBinderTest.java
+++ b/src/test/java/org/jenkinsci/plugins/workflow/multibranch/SCMBinderTest.java
@@ -48,6 +48,7 @@ import jenkins.scm.api.SCMHead;
 import jenkins.scm.api.SCMRevision;
 import jenkins.scm.api.SCMRevisionAction;
 import jenkins.scm.api.SCMSourceDescriptor;
+import jenkins.scm.impl.subversion.SubversionSCMFileSystem;
 import jenkins.scm.impl.subversion.SubversionSCMSource;
 import static org.hamcrest.Matchers.*;
 
@@ -129,6 +130,9 @@ public class SCMBinderTest {
         }
     }
 
+    static {
+        System.setProperty(SubversionSCMFileSystem.DISABLE_PROPERTY, "true");
+    }
     @Test public void exactRevisionSubversion() throws Exception {
         sampleSvnRepo.init();
         ScriptApproval sa = ScriptApproval.get();
@@ -164,7 +168,7 @@ public class SCMBinderTest {
         assertTrue(iterator.hasNext());
         ChangeLogSet.Entry entry = iterator.next();
         assertEquals("tweaked", entry.getMsg());
-        assertEquals("[/prj/trunk/Jenkinsfile, /prj/trunk/file]", new TreeSet<>(entry.getAffectedPaths()).toString());
+        assertEquals("[Jenkinsfile, file]", new TreeSet<>(entry.getAffectedPaths()).toString());
         assertFalse(iterator.hasNext());
     }
 


### PR DESCRIPTION
Continuation of #91 by @slonopotamus, picking up https://github.com/jenkinsci/subversion-plugin/pull/240 while adapting to https://github.com/jenkinsci/subversion-plugin/pull/183 + https://github.com/jenkinsci/subversion-plugin/pull/223, all originally (?) to adapt to https://github.com/jenkinsci/jenkins-test-harness/pull/166. Follow-ups would be

* extract SVN tests to `subversion-plugin`, analogous to #17
* switch most dependencies to the BOM