### PR TITLE
[JENKINS-53705] - add support for build parameters

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -68,6 +68,7 @@ THE SOFTWARE.
         <java.level>8</java.level>
         <jenkins.version>2.176.4</jenkins.version>
         <no-test-jar>false</no-test-jar>
+        <no-test-jar>false</no-test-jar>
         <workflow-job-plugin.version>2.39</workflow-job-plugin.version> <!-- TODO: Remove after https://github.com/jenkinsci/bom/pull/264 is released. -->
         <subversion-plugin.version>2.13.0</subversion-plugin.version>
     </properties>
@@ -107,6 +108,7 @@ THE SOFTWARE.
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>scm-api</artifactId>
+            <version>2.6.4-20200525.215035-2</version>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
@@ -131,6 +133,7 @@ THE SOFTWARE.
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>scm-api</artifactId>
+            <version>2.6.4-20200525.215035-2</version>
             <classifier>tests</classifier>
             <scope>test</scope>
         </dependency>

--- a/src/main/java/org/jenkinsci/plugins/workflow/multibranch/ReadTrustedStep.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/multibranch/ReadTrustedStep.java
@@ -98,7 +98,7 @@ public class ReadTrustedStep extends AbstractStepImpl {
                     if (defn instanceof CpsScmFlowDefinition) {
                         // JENKINS-31386: retrofit to work with standalone projects, without doing any trust checks.
                         standaloneSCM = ((CpsScmFlowDefinition) defn).getScm();
-                        try (SCMFileSystem fs = SCMBinder.USE_HEAVYWEIGHT_CHECKOUT ? null : SCMFileSystem.of(job, standaloneSCM)) {
+                        try (SCMFileSystem fs = SCMBinder.USE_HEAVYWEIGHT_CHECKOUT ? null : SCMFileSystem.of(build, standaloneSCM)) {
                             if (fs != null) { // JENKINS-33273
                                 try {
                                     String text = fs.child(step.path).contentAsString();


### PR DESCRIPTION
[JENKINS-53705](https://issues.jenkins-ci.org/browse/JENKINS-53705)

relates to 

* git-plugin: https://github.com/jenkinsci/git-plugin/pull/898
* git-plugin: https://github.com/jenkinsci/git-plugin/pull/772
* workflow-cps-plugin: https://github.com/jenkinsci/workflow-cps-plugin/pull/329
* scm-api-plugin addition: https://github.com/tgatinea/scm-api-plugin/pull/1
* scm-api-plugin: https://github.com/jenkinsci/scm-api-plugin/pull/78