### PR TITLE
Move matrix-auth to bom version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -230,7 +230,6 @@ THE SOFTWARE.
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>matrix-auth</artifactId>
-            <version>2.2</version>
             <scope>test</scope>
         </dependency>
         <dependency>


### PR DESCRIPTION
Missed one plugin, doing this instead of #106 .