### PR TITLE
Add description in test to prevent PCT failure in newer Jenkins versions

### DIFF
--- a/src/test/java/org/jenkinsci/plugins/workflow/multibranch/JobPropertyStepTest.java
+++ b/src/test/java/org/jenkinsci/plugins/workflow/multibranch/JobPropertyStepTest.java
@@ -236,8 +236,8 @@ public class JobPropertyStepTest {
     @Test
     public void testChoiceParameterSnippetizer() throws Exception {
         //new SnippetizerTester(r).assertGenerateSnippet();
-        new SnippetizerTester(r).assertRoundTrip(new JobPropertyStep(Collections.singletonList(new ParametersDefinitionProperty(new ChoiceParameterDefinition("paramName", new String[]{"foo", "bar", "baz"}, "")))),
-            "properties([parameters([choice(choices: ['foo', 'bar', 'baz'], description: '', name: 'paramName')])])");
+        new SnippetizerTester(r).assertRoundTrip(new JobPropertyStep(Collections.singletonList(new ParametersDefinitionProperty(new ChoiceParameterDefinition("paramName", new String[]{"foo", "bar", "baz"}, "test")))),
+                "properties([parameters([choice(choices: ['foo', 'bar', 'baz'], description: 'test', name: 'paramName')])])");
     }
 
     @SuppressWarnings("deprecation") // RunList.size


### PR DESCRIPTION
Due to jenkinsci/jenkins#5275 a test breaks PCT and is blocking jenkinsci/bom#511.

Adapt the test to work for the plugin's version of jenkins and for the later releases of jenkins

Tested manually with `mvn clean install -Djenkins.version=2.289`

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your master branch!
- [ ] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information
-->
