### PR TITLE
Added `JobPropertyStepTest.triggerWithParameter`

### DIFF
--- a/src/test/java/org/jenkinsci/plugins/workflow/multibranch/JobPropertyStepTest.java
+++ b/src/test/java/org/jenkinsci/plugins/workflow/multibranch/JobPropertyStepTest.java
@@ -168,6 +168,7 @@ public class JobPropertyStepTest {
         assertEquals(3, lr.getArtifactNumToKeep());
     }
 
+    @Issue("JENKINS-35698")
     @Test public void useParameter() throws Exception {
         sampleRepo.init();
         sampleRepo.write("Jenkinsfile",
@@ -230,6 +231,13 @@ public class JobPropertyStepTest {
         WorkflowRun b9 = r.assertBuildStatusSuccess(p.scheduleBuild2(0, new ParametersAction(new StringParameterValue("select", "bar", ""))));
         assertEquals(9, b9.getNumber());
         r.assertLogContains("value bar", b9);
+    }
+
+    @Issue({"JENKINS-27295", "https://www.jenkins.io/security/advisory/2016-05-11/#arbitrary-build-parameters-are-passed-to-build-scripts-as-environment-variables"})
+    @Test public void triggerWithParameter() throws Exception {
+        WorkflowJob p = r.createProject(WorkflowJob.class, "p");
+        p.setDefinition(new CpsFlowDefinition("properties([parameters([string(name: 'myparam')])]); echo(/got $params.myparam though the env var is $env.myparam/)", true));
+        r.assertLogContains("got the value though the env var is null", r.assertBuildStatusSuccess(p.scheduleBuild2(0, new ParametersAction(new StringParameterValue("myparam", "the value")))));
     }
 
     @Issue("JENKINS-26143")


### PR DESCRIPTION
Proof that even when defining parameters via the `properties` step on an initial build of a project, the fix of SECURITY-170 only blocks access to parameters as environment variables. They can always be accessed via the `params` map (since that poses no Shellshock risk).
