### PR TITLE
Loosening `JobPropertyStepTest#configRoundTripBuildDiscarder`.

### DIFF
--- a/src/test/java/org/jenkinsci/plugins/workflow/multibranch/JobPropertyStepTest.java
+++ b/src/test/java/org/jenkinsci/plugins/workflow/multibranch/JobPropertyStepTest.java
@@ -155,7 +155,7 @@ public class JobPropertyStepTest {
 
         StepConfigTester tester = new StepConfigTester(r);
         properties = tester.configRoundTrip(new JobPropertyStep(properties)).getProperties();
-        assertEquals(1, properties.size());
+        assertFalse(properties.isEmpty());
         BuildDiscarderProperty bdp = getPropertyFromList(BuildDiscarderProperty.class, properties);
         assertNotNull(bdp);
         BuildDiscarder strategy = bdp.getStrategy();


### PR DESCRIPTION
See jenkinsci/bom#471 and jenkinsci/bom#472. These PRs are attempting to add new plugins to the BOM, which trip up `JobPropertyStepTest#configRoundTripBuildDiscarder`. `JobPropertyStepTest#configRoundTripBuildDiscarder` expects to see exactly one job property after round-tripping the configuration. But when those other two plugins are on the classpath, round-tripping has three job properties:

```
0 = {BuildDiscarderProperty@11636}
1 = {RebuildSettings@11637}
2 = {ThrottleJobProperty@11638}
```

This PR simply loosens the test to allow for additional job properties to be present. This allows PCT to pass when Rebuild and Throttle Concurrent Builds are also on the classpath.