### PR TITLE
JENKINS-61654: use rev from upstream where possible

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -103,6 +103,21 @@ THE SOFTWARE.
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
+            <artifactId>git</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.jenkins-ci.plugins</groupId>
+            <artifactId>github-branch-source</artifactId>
+            <version>2.10.2</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.apache.commons</groupId>
+                    <artifactId>commons-lang3</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>branch-api</artifactId>
         </dependency>
         <dependency>
@@ -158,11 +173,6 @@ THE SOFTWARE.
             <groupId>org.jenkins-ci.plugins.workflow</groupId>
             <artifactId>workflow-cps</artifactId>
             <classifier>tests</classifier>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.jenkins-ci.plugins</groupId>
-            <artifactId>git</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>


### PR DESCRIPTION
This PR addresses https://issues.jenkins.io/browse/JENKINS-61654

When starting a downstream build using the `build` step, the downstream build will always fetch the head commit of `SCMHead`. When the upstream build was building an older commit, the downstream job runs in a different git context, which is not really desirable.

In some cases (same Git/GitHub remote url, same branch, ... - for details see comment on `getUpstreamGitScmRevisionForSameRemote`), we can use the `SCMRevision` from upstream and use that one to both fetch the Jenkinsfile as well as checking out the repo.


Also, I'd love some more input:

- There is a new test case, however I can not get it to work because my `CauseAction`/`UpstreamCause` is not used, and I can't find out why.
- Is this a viable approach? Esp. seeing that I need to include the branch-source-plugin dependency, I'm not sure. Maybe an [Extension Point in a similar manner to the branch source plugin](https://github.com/jenkinsci/github-branch-source-plugin/blob/master/docs/implementation.adoc) would be better, so that there can be multiple smaller Plugins for each `SCMSource` to use the upstream `SCMRevision`?
- Is there something missing? A thing I already have on my radar is hiding this behind a behavior and turning it off per default, so existing pipelines are not affected. 

.
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue
