### PR TITLE
Security fix test compatibility

### DIFF
--- a/src/test/java/org/jenkinsci/plugins/workflow/multibranch/ReadTrustedStepTest.java
+++ b/src/test/java/org/jenkinsci/plugins/workflow/multibranch/ReadTrustedStepTest.java
@@ -322,7 +322,10 @@ public class ReadTrustedStepTest {
         FileUtils.copyDirectory(new File(sampleRepo.getRoot(), ".git"), gitDirInSvnRepo);
         String jenkinsRootDir = r.jenkins.getRootDir().toString();
         // Add a Git post-checkout hook to the .git folder in the SVN repo.
-        Files.write(gitDirInSvnRepo.toPath().resolve("hooks/post-checkout"), ("#!/bin/sh\ntouch '" + jenkinsRootDir + "/hook-executed'\n").getBytes(StandardCharsets.UTF_8));
+        Path postCheckoutHook = gitDirInSvnRepo.toPath().resolve("hooks/post-checkout");
+        // Always create hooks directory for compatibility with https://github.com/jenkinsci/git-plugin/pull/1207.
+        Files.createDirectories(postCheckoutHook.getParent());
+        Files.write(postCheckoutHook, ("#!/bin/sh\ntouch '" + jenkinsRootDir + "/hook-executed'\n").getBytes(StandardCharsets.UTF_8));
         sampleRepoSvn.svnkit("add", sampleRepoSvn.wc() + "/Jenkinsfile");
         sampleRepoSvn.svnkit("add", sampleRepoSvn.wc() + "/.git");
         sampleRepoSvn.svnkit("propset", "svn:executable", "ON", sampleRepoSvn.wc() + "/.git/hooks/post-checkout");
@@ -357,7 +360,10 @@ public class ReadTrustedStepTest {
         FileUtils.copyDirectory(new File(sampleRepo.getRoot(), ".git"), gitDirInSvnRepo);
         String jenkinsRootDir = r.jenkins.getRootDir().toString();
         // Add a Git post-checkout hook to the .git folder in the SVN repo.
-        Files.write(gitDirInSvnRepo.toPath().resolve("hooks/post-checkout"), ("#!/bin/sh\ntouch '" + jenkinsRootDir + "/hook-executed'\n").getBytes(StandardCharsets.UTF_8));
+        Path postCheckoutHook = gitDirInSvnRepo.toPath().resolve("hooks/post-checkout");
+        // Always create hooks directory for compatibility with https://github.com/jenkinsci/git-plugin/pull/1207.
+        Files.createDirectories(postCheckoutHook.getParent());
+        Files.write(postCheckoutHook, ("#!/bin/sh\ntouch '" + jenkinsRootDir + "/hook-executed'\n").getBytes(StandardCharsets.UTF_8));
         sampleRepoSvn.svnkit("add", sampleRepoSvn.wc() + "/Jenkinsfile");
         sampleRepoSvn.svnkit("add", sampleRepoSvn.wc() + "/.git");
         sampleRepoSvn.svnkit("propset", "svn:executable", "ON", sampleRepoSvn.wc() + "/.git/hooks/post-checkout");

--- a/src/test/java/org/jenkinsci/plugins/workflow/multibranch/ReadTrustedStepTest.java
+++ b/src/test/java/org/jenkinsci/plugins/workflow/multibranch/ReadTrustedStepTest.java
@@ -232,12 +232,13 @@ public class ReadTrustedStepTest {
 
         WorkflowRun b = p.getLastBuild();
         assertEquals(1, b.getNumber());
-        r.assertLogContains("secrets/master.key references a file that is not inside " + r.jenkins.getWorkspaceFor(p).getRemote(), b);
+        r.assertLogContains("master.key references a file that is not inside " + r.jenkins.getWorkspaceFor(p).getRemote(), b);
     }
 
     @Issue("SECURITY-2491")
     @Test
     public void symlinksInReadTrustedCannotEscapeWorkspaceContext() throws Exception {
+        assumeFalse(Functions.isWindows()); // On Windows, the symlink is treated as a regular file, so there is no vulnerability, but the behavior is different.
         SCMBinder.USE_HEAVYWEIGHT_CHECKOUT = true;
         sampleRepo.init();
         sampleRepo.write("Jenkinsfile", "node { checkout scm; echo \"${readTrusted 'secrets/master.key'}\"}");
@@ -259,6 +260,7 @@ public class ReadTrustedStepTest {
     @Issue("SECURITY-2491")
     @Test
     public void symlinksInUntrustedRevisionCannotEscapeWorkspace() throws Exception {
+        assumeFalse(Functions.isWindows()); // On Windows, the symlink is treated as a regular file, so there is no vulnerability, but the behavior is different.
         SCMBinder.USE_HEAVYWEIGHT_CHECKOUT = true;
         sampleRepo.init();
         sampleRepo.write("Jenkinsfile", "node { checkout scm; echo \"${readTrusted 'secrets/master.key'}\"}");
@@ -286,6 +288,7 @@ public class ReadTrustedStepTest {
     @Issue("SECURITY-2491")
     @Test
     public void symlinksInNonMultibranchCannotEscapeWorkspaceContextViaReadTrusted() throws Exception {
+        assumeFalse(Functions.isWindows()); // On Windows, the symlink is treated as a regular file, so there is no vulnerability, but the behavior is different.
         SCMBinder.USE_HEAVYWEIGHT_CHECKOUT = true;
         sampleRepo.init();
         sampleRepo.write("Jenkinsfile", "echo \"${readTrusted 'master.key'}\"");


### PR DESCRIPTION
The tests for the security fixes for https://www.jenkins.io/security/advisory/2022-02-15/ fail on Windows due to differences in behavior. Two currently ignored tests (they need an updated workflow-cps dependency) would also fail against recent versions of Git plugin due to https://github.com/jenkinsci/git-plugin/pull/1207, so I fixed that at the same time.

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md  in your own repository 
-->
