### PR TITLE
add java 11 back for linux

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -2,5 +2,6 @@ buildPlugin(
   useContainerAgent: true,
   configurations: [
     [platform: 'linux', jdk: 17],
+    [platform: 'linux', jdk: 11],
     [platform: 'windows', jdk: 11],
 ])


### PR DESCRIPTION
I missed that @jglick had enabled auto merge in #219 so the [feedback](https://github.com/jenkinsci/workflow-multibranch-plugin/pull/219#discussion_r1049496731) did not even get looked at before it was merged.

ideally you should only change one variable at once so if something breaks you have a better idea of the cause. is it java11 or is it windows.
the windows agents are generally less available so you still have to wait around anyway (or they are just broken in which case you have no idea if it even works on java 11)

<!-- Please describe your pull request here. -->

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md  in your own repository 
-->
