### PR TITLE
Adding symbol to the WorkflowMultiBranchProject class descriptor

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/workflow/multibranch/WorkflowMultiBranchProject.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/multibranch/WorkflowMultiBranchProject.java
@@ -134,7 +134,7 @@ public class WorkflowMultiBranchProject extends MultiBranchProject<WorkflowJob,W
                 strategy != null ? strategy.getPropertiesFor(head) : Collections.emptyList()));
     }
 
-    @Extension(ordinal = 1000) @Symbol({"multibranch"})
+    @Extension @Symbol({"multibranch"})
     public static class DescriptorImpl extends MultiBranchProjectDescriptor implements IconSpec {
 
         @NonNull

--- a/src/main/java/org/jenkinsci/plugins/workflow/multibranch/WorkflowMultiBranchProject.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/multibranch/WorkflowMultiBranchProject.java
@@ -54,6 +54,7 @@ import org.apache.commons.lang.StringUtils;
 import org.jenkins.ui.icon.Icon;
 import org.jenkins.ui.icon.IconSet;
 import org.jenkins.ui.icon.IconSpec;
+import org.jenkinsci.Symbol;
 import org.jenkinsci.plugins.workflow.cps.Snippetizer;
 import org.jenkinsci.plugins.workflow.job.WorkflowJob;
 import org.jenkinsci.plugins.workflow.job.WorkflowRun;
@@ -133,7 +134,8 @@ public class WorkflowMultiBranchProject extends MultiBranchProject<WorkflowJob,W
                 strategy != null ? strategy.getPropertiesFor(head) : Collections.emptyList()));
     }
 
-    @Extension public static class DescriptorImpl extends MultiBranchProjectDescriptor implements IconSpec {
+    @Extension(ordinal = 1000) @Symbol({"multibranch"})
+    public static class DescriptorImpl extends MultiBranchProjectDescriptor implements IconSpec {
 
         @NonNull
         @Override public String getDisplayName() {

--- a/src/test/java/org/jenkinsci/plugins/workflow/multibranch/WorkflowMultiBranchProjectTest.java
+++ b/src/test/java/org/jenkinsci/plugins/workflow/multibranch/WorkflowMultiBranchProjectTest.java
@@ -26,8 +26,6 @@ package org.jenkinsci.plugins.workflow.multibranch;
 
 import com.cloudbees.hudson.plugins.folder.computed.FolderComputation;
 import edu.umd.cs.findbugs.annotations.NonNull;
-import hudson.ExtensionList;
-import hudson.model.Descriptor;
 import hudson.model.DescriptorVisibilityFilter;
 import hudson.model.Item;
 import hudson.model.Queue;
@@ -60,7 +58,6 @@ import jenkins.scm.api.SCMSource;
 import jenkins.scm.impl.SingleSCMSource;
 import static org.hamcrest.Matchers.*;
 
-import org.jenkinsci.Symbol;
 import org.jenkinsci.plugins.workflow.job.WorkflowJob;
 import org.jenkinsci.plugins.workflow.job.WorkflowRun;
 import static org.junit.Assert.*;

--- a/src/test/java/org/jenkinsci/plugins/workflow/multibranch/WorkflowMultiBranchProjectTest.java
+++ b/src/test/java/org/jenkinsci/plugins/workflow/multibranch/WorkflowMultiBranchProjectTest.java
@@ -57,7 +57,6 @@ import jenkins.scm.api.SCMHead;
 import jenkins.scm.api.SCMSource;
 import jenkins.scm.impl.SingleSCMSource;
 import static org.hamcrest.Matchers.*;
-
 import org.jenkinsci.plugins.workflow.job.WorkflowJob;
 import org.jenkinsci.plugins.workflow.job.WorkflowRun;
 import static org.junit.Assert.*;
@@ -267,4 +266,5 @@ public class WorkflowMultiBranchProjectTest {
         r.assertLogContains("ALTERNATIVE CONTENT", b2);
         r.assertLogContains("branch=feature2", b2);
     }
+
 }

--- a/src/test/java/org/jenkinsci/plugins/workflow/multibranch/WorkflowMultiBranchProjectTest.java
+++ b/src/test/java/org/jenkinsci/plugins/workflow/multibranch/WorkflowMultiBranchProjectTest.java
@@ -26,9 +26,12 @@ package org.jenkinsci.plugins.workflow.multibranch;
 
 import com.cloudbees.hudson.plugins.folder.computed.FolderComputation;
 import edu.umd.cs.findbugs.annotations.NonNull;
+import hudson.ExtensionList;
+import hudson.model.Descriptor;
 import hudson.model.DescriptorVisibilityFilter;
 import hudson.model.Item;
 import hudson.model.Queue;
+import hudson.model.TopLevelItem;
 import hudson.model.listeners.ItemListener;
 import hudson.plugins.git.GitSCM;
 import hudson.scm.ChangeLogParser;
@@ -57,6 +60,8 @@ import jenkins.scm.api.SCMHead;
 import jenkins.scm.api.SCMSource;
 import jenkins.scm.impl.SingleSCMSource;
 import static org.hamcrest.Matchers.*;
+
+import org.jenkinsci.Symbol;
 import org.jenkinsci.plugins.workflow.job.WorkflowJob;
 import org.jenkinsci.plugins.workflow.job.WorkflowRun;
 import static org.junit.Assert.*;
@@ -265,6 +270,18 @@ public class WorkflowMultiBranchProjectTest {
         assertEquals(1, b2.getNumber());
         r.assertLogContains("ALTERNATIVE CONTENT", b2);
         r.assertLogContains("branch=feature2", b2);
+    }
+
+    @Test public void getProjectClassBySymbol(){
+        Descriptor descriptor = ExtensionList.lookup(Descriptor.class).stream().filter(d -> {
+            Symbol annotation = d.getClass().getAnnotation(Symbol.class);
+            if (annotation == null) {
+                return false;
+            }
+            return Arrays.asList(annotation.value()).contains("multibranch");
+        }).findFirst().orElse(null);
+
+        assertNotNull(descriptor);
     }
 
 }

--- a/src/test/java/org/jenkinsci/plugins/workflow/multibranch/WorkflowMultiBranchProjectTest.java
+++ b/src/test/java/org/jenkinsci/plugins/workflow/multibranch/WorkflowMultiBranchProjectTest.java
@@ -31,7 +31,6 @@ import hudson.model.Descriptor;
 import hudson.model.DescriptorVisibilityFilter;
 import hudson.model.Item;
 import hudson.model.Queue;
-import hudson.model.TopLevelItem;
 import hudson.model.listeners.ItemListener;
 import hudson.plugins.git.GitSCM;
 import hudson.scm.ChangeLogParser;

--- a/src/test/java/org/jenkinsci/plugins/workflow/multibranch/WorkflowMultiBranchProjectTest.java
+++ b/src/test/java/org/jenkinsci/plugins/workflow/multibranch/WorkflowMultiBranchProjectTest.java
@@ -270,17 +270,4 @@ public class WorkflowMultiBranchProjectTest {
         r.assertLogContains("ALTERNATIVE CONTENT", b2);
         r.assertLogContains("branch=feature2", b2);
     }
-
-    @Test public void getProjectClassBySymbol(){
-        Descriptor descriptor = ExtensionList.lookup(Descriptor.class).stream().filter(d -> {
-            Symbol annotation = d.getClass().getAnnotation(Symbol.class);
-            if (annotation == null) {
-                return false;
-            }
-            return Arrays.asList(annotation.value()).contains("multibranch");
-        }).findFirst().orElse(null);
-
-        assertNotNull(descriptor);
-    }
-
 }


### PR DESCRIPTION
<!-- Please describe your pull request here. -->
 The WorkflowMultiBranchProject class does not have a proper Symbol in the descriptor as many other such as FreeStyleProject (https://github.com/jenkinsci/jenkins/blob/master/core/src/main/java/hudson/model/FreeStyleProject.java#L79)


- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [ ] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md  in your own repository 
-->
