### PR TITLE
Adapt standard Jenkins icons

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -120,6 +120,10 @@ THE SOFTWARE.
             <artifactId>script-security</artifactId>
         </dependency>
         <dependency>
+            <groupId>io.jenkins.plugins</groupId>
+            <artifactId>ionicons-api</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>scm-api</artifactId>
             <classifier>tests</classifier>

--- a/src/main/resources/org/jenkinsci/plugins/workflow/multibranch/WorkflowBranchProjectFactory/getting-started-links.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/workflow/multibranch/WorkflowBranchProjectFactory/getting-started-links.jelly
@@ -4,7 +4,7 @@
         <a href="https://www.jenkins.io/doc/book/pipeline/" class="content-block__link content-block__help-link">
             <span>Creating a Jenkins Pipeline</span>
             <span class="trailing-icon">
-                <l:svgIcon class="icon-sm" href="${imagesURL}/material-icons/svg-sprite-content-symbol.svg#ic_link_24px" />
+                <l:icon class="icon-sm" src="symbol-link-outline plugin-ionicons-api" />
             </span>
         </a>
     </li>
@@ -12,7 +12,7 @@
         <a href="https://www.jenkins.io/doc/book/pipeline/multibranch/" class="content-block__link content-block__help-link">
             <span>Creating Multibranch Projects</span>
             <span class="trailing-icon">
-                <l:svgIcon class="icon-sm" href="${imagesURL}/material-icons/svg-sprite-content-symbol.svg#ic_link_24px" />
+                <l:icon class="icon-sm" src="symbol-link-outline plugin-ionicons-api" />
             </span>
         </a>
     </li>

--- a/src/main/resources/org/jenkinsci/plugins/workflow/multibranch/WorkflowMultiBranchProjectFactory/getting-started-links.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/workflow/multibranch/WorkflowMultiBranchProjectFactory/getting-started-links.jelly
@@ -4,7 +4,7 @@
         <a href="https://www.jenkins.io/doc/book/pipeline/" class="content-block__link content-block__help-link">
             <span>Creating a Jenkins Pipeline</span>
             <span class="trailing-icon">
-                <l:svgIcon class="icon-sm" href="${imagesURL}/material-icons/svg-sprite-content-symbol.svg#ic_link_24px" />
+                <l:icon class="icon-sm" src="symbol-link-outline plugin-ionicons-api" />
             </span>
         </a>
     </li>
@@ -12,7 +12,7 @@
         <a href="https://www.jenkins.io/doc/book/pipeline/multibranch/" class="content-block__link content-block__help-link">
             <span>Creating Multibranch Projects</span>
             <span class="trailing-icon">
-                <l:svgIcon class="icon-sm" href="${imagesURL}/material-icons/svg-sprite-content-symbol.svg#ic_link_24px" />
+                <l:icon class="icon-sm" src="symbol-link-outline plugin-ionicons-api" />
             </span>
         </a>
     </li>


### PR DESCRIPTION
The change proposed adapts the standard Jenkins icons (ionicons) used in core itself. In this case, the icons look most the same, but ionicons support our theme-ability API and are recommended to use.