### PR TITLE
Forward compatibility with Guice 7

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -63,7 +63,7 @@ THE SOFTWARE.
     </pluginRepositories>
     <properties>
         <changelist>999999-SNAPSHOT</changelist>
-        <jenkins.version>2.387.3</jenkins.version>
+        <jenkins.version>2.414.3</jenkins.version>
         <no-test-jar>false</no-test-jar>
         <gitHubRepo>jenkinsci/${project.artifactId}-plugin</gitHubRepo>
     </properties>
@@ -71,8 +71,8 @@ THE SOFTWARE.
         <dependencies>
             <dependency>
                 <groupId>io.jenkins.tools.bom</groupId>
-                <artifactId>bom-2.387.x</artifactId>
-                <version>2163.v2d916d90c305</version>
+                <artifactId>bom-2.414.x</artifactId>
+                <version>2705.vf5c48c31285b_</version>
                 <scope>import</scope>
                 <type>pom</type>
             </dependency>

--- a/src/main/java/org/jenkinsci/plugins/workflow/multibranch/JobPropertyStep.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/multibranch/JobPropertyStep.java
@@ -44,7 +44,7 @@ import java.util.Map;
 import java.util.Set;
 import java.util.logging.Level;
 import java.util.logging.Logger;
-import javax.inject.Inject;
+import jakarta.inject.Inject;
 
 import hudson.model.TaskListener;
 import jenkins.branch.BuildRetentionBranchProperty;

--- a/src/main/java/org/jenkinsci/plugins/workflow/multibranch/ReadTrustedStep.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/multibranch/ReadTrustedStep.java
@@ -41,7 +41,7 @@ import hudson.slaves.WorkspaceList;
 
 import java.io.File;
 import java.io.IOException;
-import javax.inject.Inject;
+import jakarta.inject.Inject;
 import jenkins.branch.Branch;
 import jenkins.model.Jenkins;
 import jenkins.scm.api.SCMFileSystem;


### PR DESCRIPTION
Without dropping compatibility with Guice 6 (currently delivered by Jenkins core), add support for Guice 7.