### PR TITLE
Use symbol for multi branch pipeline icon

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -63,7 +63,7 @@ THE SOFTWARE.
     </pluginRepositories>
     <properties>
         <changelist>999999-SNAPSHOT</changelist>
-        <jenkins.version>2.444</jenkins.version>
+        <jenkins.version>2.454</jenkins.version>
         <no-test-jar>false</no-test-jar>
         <gitHubRepo>jenkinsci/${project.artifactId}-plugin</gitHubRepo>
     </properties>

--- a/src/main/java/org/jenkinsci/plugins/workflow/multibranch/WorkflowMultiBranchProject.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/multibranch/WorkflowMultiBranchProject.java
@@ -153,7 +153,7 @@ public class WorkflowMultiBranchProject extends MultiBranchProject<WorkflowJob,W
 
         @Override
         public String getIconClassName() {
-            return "icon-pipeline-multibranch-project";
+            return "symbol-git-branch-outline plugin-ionicons-api";
         }
 
         @Override public TopLevelItem newInstance(ItemGroup parent, String name) {


### PR DESCRIPTION
Follow up to @mawinter69 changes in core (https://github.com/jenkinsci/jenkins/pull/9127). This PR uses the branch symbol now that the 'New item' page supports displaying them.

**Before**
<img width="661" alt="image" src="https://github.com/jenkinsci/workflow-multibranch-plugin/assets/43062514/11c1cbcc-2d9c-446b-9ed4-8048d75a77cb">

**After**
<img width="685" alt="image" src="https://github.com/jenkinsci/workflow-multibranch-plugin/assets/43062514/879c4884-1ae0-4065-aa4b-16b002fe9237">

### Testing done

* Branch symbol displays as expected in the 'New item' page

```[tasklist]
### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
```

