### PR TITLE
Avoid need for `idealNames` workaround

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/workflow/multibranch/AbstractWorkflowBranchProjectFactory.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/multibranch/AbstractWorkflowBranchProjectFactory.java
@@ -64,20 +64,16 @@ public abstract class AbstractWorkflowBranchProjectFactory extends BranchProject
 
     @NonNull
     @Override public WorkflowJob setBranch(@NonNull WorkflowJob project, @NonNull Branch branch) {
-        try {
-            BulkChange bc = new BulkChange(project);
-            try {
-                project.setDefinition(createDefinition());
-                BranchJobProperty property = project.getProperty(BranchJobProperty.class);
-                if (property == null) {
-                    project.addProperty(new BranchJobProperty(branch));
-                } else { // TODO may add equality check if https://github.com/jenkinsci/branch-api-plugin/pull/36 or equivalent is implemented
-                    property.setBranch(branch);
-                    project.save();
-                }
-            } finally {
-                bc.commit();
+        try (BulkChange bc = new BulkChange(project)) {
+            project.setDefinition(createDefinition());
+            BranchJobProperty property = project.getProperty(BranchJobProperty.class);
+            if (property == null) {
+                project.addProperty(new BranchJobProperty(branch));
+            } else { // TODO may add equality check if https://github.com/jenkinsci/branch-api-plugin/pull/36 or equivalent is implemented
+                property.setBranch(branch);
+                project.save();
             }
+            bc.commit();
         } catch (IOException x) {
             LOGGER.log(Level.WARNING, null, x);
         }

--- a/src/main/java/org/jenkinsci/plugins/workflow/multibranch/AbstractWorkflowBranchProjectFactory.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/multibranch/AbstractWorkflowBranchProjectFactory.java
@@ -25,6 +25,7 @@
 package org.jenkinsci.plugins.workflow.multibranch;
 
 import edu.umd.cs.findbugs.annotations.NonNull;
+import hudson.BulkChange;
 import hudson.model.Item;
 import java.io.IOException;
 import java.util.logging.Level;
@@ -63,14 +64,19 @@ public abstract class AbstractWorkflowBranchProjectFactory extends BranchProject
 
     @NonNull
     @Override public WorkflowJob setBranch(@NonNull WorkflowJob project, @NonNull Branch branch) {
-        project.setDefinition(createDefinition());
-        BranchJobProperty property = project.getProperty(BranchJobProperty.class);
         try {
-            if (property == null) {
-                project.addProperty(new BranchJobProperty(branch));
-            } else { // TODO may add equality check if https://github.com/jenkinsci/branch-api-plugin/pull/36 or equivalent is implemented
-                property.setBranch(branch);
-                project.save();
+            BulkChange bc = new BulkChange(project);
+            try {
+                project.setDefinition(createDefinition());
+                BranchJobProperty property = project.getProperty(BranchJobProperty.class);
+                if (property == null) {
+                    project.addProperty(new BranchJobProperty(branch));
+                } else { // TODO may add equality check if https://github.com/jenkinsci/branch-api-plugin/pull/36 or equivalent is implemented
+                    property.setBranch(branch);
+                    project.save();
+                }
+            } finally {
+                bc.commit();
             }
         } catch (IOException x) {
             LOGGER.log(Level.WARNING, null, x);


### PR DESCRIPTION
Testing with

```java
diff --git a/src/test/java/org/jenkinsci/plugins/workflow/multibranch/WorkflowMultiBranchProjectTest.java b/src/test/java/org/jenkinsci/plugins/workflow/multibranch/WorkflowMultiBranchProjectTest.java
index 86d2af8..501a484 100644
--- a/src/test/java/org/jenkinsci/plugins/workflow/multibranch/WorkflowMultiBranchProjectTest.java
+++ b/src/test/java/org/jenkinsci/plugins/workflow/multibranch/WorkflowMultiBranchProjectTest.java
@@ -233,7 +233,7 @@ public class WorkflowMultiBranchProjectTest {
     @Test public void configuredScriptNameBranches() throws Exception {
         sampleRepo.init();
 
-        WorkflowMultiBranchProject mp = r.jenkins.createProject(WorkflowMultiBranchProject.class, "p");
+        WorkflowMultiBranchProject mp = r.jenkins.createProject(WorkflowMultiBranchProject.class, "ElNiño");
         mp.getSourcesList().add(new BranchSource(new GitSCMSource(null, sampleRepo.toString(), "", "*", "", false), new DefaultBranchPropertyStrategy(new BranchProperty[0])));
         for (SCMSource source : mp.getSCMSources()) {
             assertEquals(mp, source.getOwner());
@@ -248,30 +248,30 @@ public class WorkflowMultiBranchProjectTest {
         mp.scheduleBuild2(0).getFuture().get();
         assertNull(mp.getItem("master"));
 
-        sampleRepo.git("checkout", "-b", "feature");
+        sampleRepo.git("checkout", "-b", "feature/1");
         sampleRepo.write("another-Jenkinsfile", "echo(/branch=$BRANCH_NAME/); node {checkout scm; echo readFile('file')}");
         sampleRepo.git("add", "another-Jenkinsfile");
         sampleRepo.write("file", "subsequent content");
         sampleRepo.git("commit", "--all", "--message=feature-create");
-        WorkflowJob p1 = scheduleAndFindBranchProject(mp, "feature");
+        WorkflowJob p1 = scheduleAndFindBranchProject(mp, "feature/1");
         assertEquals(1, mp.getItems().size());
         r.waitUntilNoActivity();
         WorkflowRun b1 = p1.getLastBuild();
         assertEquals(1, b1.getNumber());
         r.assertLogContains("subsequent content", b1);
-        r.assertLogContains("branch=feature", b1);
+        r.assertLogContains("branch=feature/1", b1);
 
-        sampleRepo.git("checkout", "-b", "feature2");
+        sampleRepo.git("checkout", "-b", "feature/2");
         sampleRepo.write("another-Jenkinsfile", "echo(/branch=$BRANCH_NAME/); node {checkout scm; echo readFile('file').toUpperCase()}");
         sampleRepo.write("file", "alternative content");
         sampleRepo.git("commit", "--all", "--message=feature2-create");
-        WorkflowJob p2 = scheduleAndFindBranchProject(mp, "feature2");
+        WorkflowJob p2 = scheduleAndFindBranchProject(mp, "feature/2");
         assertEquals(2, mp.getItems().size());
         r.waitUntilNoActivity();
         WorkflowRun b2 = p2.getLastBuild();
         assertEquals(1, b2.getNumber());
         r.assertLogContains("ALTERNATIVE CONTENT", b2);
-        r.assertLogContains("branch=feature2", b2);
+        r.assertLogContains("branch=feature/2", b2);
     }
 
     @Issue("JENKINS-72613")
```

I tested to see if the `idealNames` workaround in `cloudbees-folder` was still necessary. I found a usage here:

```
idealNameFromItem:151, ChildNameGenerator (com.cloudbees.hudson.plugins.folder)
dirNameFromItem:248, MultiBranchProjectDescriptor$ChildNameGeneratorImpl (jenkins.branch)
dirNameFromItem:222, MultiBranchProjectDescriptor$ChildNameGeneratorImpl (jenkins.branch)
dirName:198, ChildNameGenerator (com.cloudbees.hudson.plugins.folder)
getRootDirFor:543, AbstractFolder (com.cloudbees.hudson.plugins.folder)
getRootDirFor:878, MultiBranchProject (jenkins.branch)
getRootDirFor:130, MultiBranchProject (jenkins.branch)
getRootDir:196, AbstractItem (hudson.model)
getConfigFile:391, Items (hudson.model)
getConfigFile:624, AbstractItem (hudson.model)
save:619, AbstractItem (hudson.model)
save:203, Job (hudson.model)
setDefinition:172, WorkflowJob (org.jenkinsci.plugins.workflow.job)
setBranch:66, AbstractWorkflowBranchProjectFactory (org.jenkinsci.plugins.workflow.multibranch)
newInstance:55, AbstractWorkflowBranchProjectFactory (org.jenkinsci.plugins.workflow.multibranch)
newInstance:45, AbstractWorkflowBranchProjectFactory (org.jenkinsci.plugins.workflow.multibranch)
observeNew:2109, MultiBranchProject$SCMHeadObserverImpl (jenkins.branch)
observe:2031, MultiBranchProject$SCMHeadObserverImpl (jenkins.branch)
process:357, SCMSourceRequest (jenkins.scm.api.trait)
discoverBranches:728, AbstractGitSCMSource$8 (jenkins.plugins.git)
run:632, AbstractGitSCMSource$8 (jenkins.plugins.git)
run:611, AbstractGitSCMSource$8 (jenkins.plugins.git)
doRetrieve:415, AbstractGitSCMSource (jenkins.plugins.git)
doRetrieve:352, AbstractGitSCMSource (jenkins.plugins.git)
retrieve:611, AbstractGitSCMSource (jenkins.plugins.git)
_retrieve:372, SCMSource (jenkins.scm.api)
fetch:282, SCMSource (jenkins.scm.api)
computeChildren:662, MultiBranchProject (jenkins.branch)
updateChildren:272, ComputedFolder (com.cloudbees.hudson.plugins.folder.computed)
run:171, FolderComputation (com.cloudbees.hudson.plugins.folder.computed)
run:1065, MultiBranchProject$BranchIndexing (jenkins.branch)
execute:101, ResourceController (hudson.model)
run:445, Executor (hudson.model)
```

This must have been the problem @stephenc had in mind when he wrote:

> There are some items which need the `Item#getRootDir()` during construction (those are bold evil item types that leak side-effects, you should fix them if you find them).

I have found it, and I am fixing it. Here the problem is that `WorkflowJob#setDefinition` triggers a save (which needs the unmangled name) before we have added the `BranchJobProperty` to record the unmangled name. By wrapping the whole thing in a `BulkChange` we avoid the save until after the unmangled name has been recorded in `BranchJobProperty`, after which `idealNames` is no longer consulted.

### Testing done

PR build, as well as local testing with the abovementioned test diff. Verified in the debugger that `idealNames` was consulted before this PR but not after this PR.

### Submitter checklist
- [ ] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [ ] Ensure that the pull request title represents the desired changelog entry
- [ ] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
