### PR TITLE
Replace `StringUtils` with native Java Platform equivalents

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/workflow/multibranch/ResolveScmStep.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/multibranch/ResolveScmStep.java
@@ -46,7 +46,6 @@ import jenkins.scm.api.SCMRevision;
 import jenkins.scm.api.SCMSource;
 import net.sf.json.JSONArray;
 import net.sf.json.JSONObject;
-import org.apache.commons.lang.StringUtils;
 import org.jenkinsci.plugins.workflow.steps.Step;
 import org.jenkinsci.plugins.workflow.steps.StepContext;
 import org.jenkinsci.plugins.workflow.steps.StepDescriptor;
@@ -213,7 +212,7 @@ public class ResolveScmStep extends Step {
         }
 
         public FormValidation doCheckTarget(@QueryParameter String value) {
-            if (StringUtils.isNotBlank(value)) {
+            if (value != null && !value.isBlank()) {
                 return FormValidation.ok();
             }
             return FormValidation.error("You must supply a target branch name to resolve");
@@ -303,7 +302,7 @@ public class ResolveScmStep extends Step {
         public ObserverImpl(@NonNull List<String> heads) {
             heads.getClass(); // fail fast if null
             for (String head : heads) {
-                if (StringUtils.isNotBlank(head)) {
+                if (head != null && !head.isBlank()) {
                     revision.put(head, null);
                 }
             }

--- a/src/main/java/org/jenkinsci/plugins/workflow/multibranch/WorkflowBranchProjectFactory.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/multibranch/WorkflowBranchProjectFactory.java
@@ -31,7 +31,6 @@ import java.io.IOException;
 import jenkins.scm.api.SCMProbeStat;
 import jenkins.scm.api.SCMSource;
 import jenkins.scm.api.SCMSourceCriteria;
-import org.apache.commons.lang.StringUtils;
 import org.jenkinsci.plugins.workflow.flow.FlowDefinition;
 import org.kohsuke.stapler.DataBoundConstructor;
 import org.kohsuke.stapler.DataBoundSetter;
@@ -54,7 +53,7 @@ public class WorkflowBranchProjectFactory extends AbstractWorkflowBranchProjectF
 
     @DataBoundSetter
     public void setScriptPath(String scriptPath) {
-        if (StringUtils.isEmpty(scriptPath)) {
+        if (scriptPath == null || scriptPath.isEmpty()) {
             this.scriptPath = SCRIPT;
         } else {
             this.scriptPath = scriptPath;

--- a/src/main/java/org/jenkinsci/plugins/workflow/multibranch/WorkflowMultiBranchProject.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/multibranch/WorkflowMultiBranchProject.java
@@ -50,7 +50,6 @@ import jenkins.scm.api.SCMHead;
 import jenkins.scm.api.SCMRevisionAction;
 import jenkins.scm.api.SCMSource;
 import jenkins.scm.api.SCMSourceCriteria;
-import org.apache.commons.lang.StringUtils;
 import org.jenkins.ui.icon.Icon;
 import org.jenkins.ui.icon.IconSet;
 import org.jenkins.ui.icon.IconSpec;
@@ -114,7 +113,7 @@ public class WorkflowMultiBranchProject extends MultiBranchProject<WorkflowJob,W
 
     private BranchJobProperty reconstructBranchJobProperty(@NonNull WorkflowJob job, @NonNull SCMRevisionAction action) {
         String sourceId = action.getSourceId();
-        if (StringUtils.isEmpty(sourceId)) {
+        if (sourceId == null || sourceId.isEmpty()) {
             return null;
         }
         SCMHead head = action.getRevision().getHead();

--- a/src/main/java/org/jenkinsci/plugins/workflow/multibranch/WorkflowMultiBranchProjectFactory.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/multibranch/WorkflowMultiBranchProjectFactory.java
@@ -30,7 +30,6 @@ import jenkins.branch.MultiBranchProjectFactory;
 import jenkins.branch.MultiBranchProjectFactoryDescriptor;
 import jenkins.scm.api.SCMSource;
 import jenkins.scm.api.SCMSourceCriteria;
-import org.apache.commons.lang.StringUtils;
 import org.kohsuke.stapler.DataBoundConstructor;
 import org.kohsuke.stapler.DataBoundSetter;
 import java.io.IOException;
@@ -50,7 +49,7 @@ public class WorkflowMultiBranchProjectFactory extends AbstractWorkflowMultiBran
 
     @DataBoundSetter
     public void setScriptPath(String scriptPath) {
-        if (StringUtils.isEmpty(scriptPath)) {
+        if (scriptPath == null || scriptPath.isEmpty()) {
             this.scriptPath = WorkflowBranchProjectFactory.SCRIPT;
         } else {
             this.scriptPath = scriptPath;


### PR DESCRIPTION
Migrate from deprecated/EOL Commons Lang 2 to native Java Platform functionality.