### PR TITLE
Update inconsistent style for pipeline branch speed dropdown

### DIFF
--- a/src/main/resources/org/jenkinsci/plugins/workflow/multibranch/DurabilityHintBranchProperty/config.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/workflow/multibranch/DurabilityHintBranchProperty/config.jelly
@@ -25,12 +25,14 @@ THE SOFTWARE.
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
     <f:entry title="${%Custom Branch Speed/Durability Level}" field="hint">
         <j:set var="defaultHint" value="${descriptor.defaultDurabilityHint}"/>
-        <select class="setting-input" name="hint">
-            <j:forEach var="it" items="${descriptor.durabilityHintValues}">
-                <option value="${it.name()}"
-                        selected="${((instance != null) ? it==instance[field] : it==defaultHint) ? 'true' : null}"
-                        tooltip="${it.tooltip}"><j:out value="${it.description}"/></option>
-            </j:forEach>
-        </select>
+        <div class="jenkins-select">
+            <select class="jenkins-select__input" name="hint">
+                <j:forEach var="it" items="${descriptor.durabilityHintValues}">
+                    <option value="${it.name()}"
+                            selected="${((instance != null) ? it==instance[field] : it==defaultHint) ? 'true' : null}"
+                            tooltip="${it.tooltip}"><j:out value="${it.description}"/></option>
+                </j:forEach>
+            </select>
+        </div>
     </f:entry>
 </j:jelly>


### PR DESCRIPTION
<!-- Please describe your pull request here. -->
Use consistent style for pipeline branch speed dropdown
### Testing done
**Before**
<img width="1127" height="298" alt="CleanShot 2025-08-11 at 16 54 59" src="https://github.com/user-attachments/assets/7999808f-0978-444b-85fc-0a0599a20209" />

**After**
<img width="1127" height="298" alt="CleanShot 2025-08-11 at 17 06 48" src="https://github.com/user-attachments/assets/38d241d3-0588-4ed4-b931-591e500eadc2" />

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests that demonstrate the feature works or the issue is fixed

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
