### PR TITLE
`SCMBinderTest.deletedBranch` flake

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -201,6 +201,12 @@ THE SOFTWARE.
             <artifactId>junit</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.awaitility</groupId>
+            <artifactId>awaitility</artifactId>
+            <version>4.3.0</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
     <build>
         <plugins>

--- a/src/test/java/org/jenkinsci/plugins/workflow/multibranch/SCMBinderTest.java
+++ b/src/test/java/org/jenkinsci/plugins/workflow/multibranch/SCMBinderTest.java
@@ -49,6 +49,7 @@ import jenkins.scm.api.SCMHead;
 import jenkins.scm.api.SCMRevision;
 import jenkins.scm.api.SCMRevisionAction;
 import jenkins.scm.api.SCMSourceDescriptor;
+import static org.awaitility.Awaitility.await;
 import static org.hamcrest.Matchers.*;
 
 import org.springframework.security.core.Authentication;
@@ -187,6 +188,7 @@ public class SCMBinderTest {
         mp.scheduleBuild2(0).getFuture().get();
         WorkflowMultiBranchProjectTest.showIndexing(mp);
         assertEquals(1, mp.getItems().size());
+        await().until(() -> r.jenkins.getWorkspaceFor(p).getParent().list().stream().filter(d -> d.getName().contains("feature")).toList(), empty());
     }
 
     @Test public void untrustedRevisions() throws Exception {


### PR DESCRIPTION
[This flake](https://github.com/jenkinsci/workflow-multibranch-plugin/pull/569/checks?check_run_id=68193663837) in #569 might have been due to the test not waiting for `WorkspaceLocatorImpl.Deleter.CleanupTask` to finish.