### PR TITLE
Clarify NPE when resolveScm omits targets

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/workflow/multibranch/ResolveScmStep.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/multibranch/ResolveScmStep.java
@@ -39,6 +39,7 @@ import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 import jenkins.scm.api.SCMHead;
 import jenkins.scm.api.SCMHeadObserver;
@@ -90,6 +91,10 @@ public class ResolveScmStep extends Step {
     @DataBoundConstructor
     public ResolveScmStep(@NonNull SCMSource source, @NonNull List<String> targets) {
         this.source = source;
+        // JENKINS-67005: Pipeline passes null when targets is omitted from the step call.
+        Objects.requireNonNull(
+                targets,
+                "targets is required; provide candidate branch names, e.g. targets: [env.BRANCH_NAME, 'main']");
         this.targets = new ArrayList<>(targets);
     }
 

--- a/src/test/java/org/jenkinsci/plugins/workflow/multibranch/ResolveScmStepTest.java
+++ b/src/test/java/org/jenkinsci/plugins/workflow/multibranch/ResolveScmStepTest.java
@@ -25,19 +25,16 @@
 
 package org.jenkinsci.plugins.workflow.multibranch;
 
+import hudson.model.Result;
 import hudson.model.TopLevelItem;
-import java.util.Collections;
 import jenkins.scm.impl.mock.MockSCMController;
 import org.jenkinsci.plugins.workflow.cps.CpsFlowDefinition;
 import org.jenkinsci.plugins.workflow.job.WorkflowJob;
+import org.jenkinsci.plugins.workflow.job.WorkflowRun;
 import org.junit.Before;
 import org.junit.ClassRule;
 import org.junit.Test;
 import org.jvnet.hudson.test.JenkinsRule;
-
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.containsString;
-import static org.junit.Assert.fail;
 
 public class ResolveScmStepTest {
 
@@ -128,14 +125,18 @@ public class ResolveScmStepTest {
     }
 
     @Test
-    public void constructorRejectsNullTargetsWithClearMessage() {
-        try {
-            new ResolveScmStep(null, null);
-            fail("expected NullPointerException");
-        } catch (NullPointerException e) {
-            assertThat(e.getMessage(), containsString("targets is required"));
+    public void given_targetsOmitted_when_invoked_then_failsWithClearMessage() throws Exception {
+        try (MockSCMController c = MockSCMController.create()) {
+            c.createRepository("repo");
+            WorkflowJob job = j.jenkins.createProject(WorkflowJob.class, "workflow");
+            job.setDefinition(new CpsFlowDefinition("node {\n"
+                    + "  resolveScm source: mockScm(controllerId:'"
+                    + c.getId()
+                    + "', repository:'repo', traits: [discoverBranches()])\n"
+                    + "}", true));
+            WorkflowRun b = j.assertBuildStatus(Result.FAILURE, job.scheduleBuild2(0));
+            j.assertLogContains("targets is required", b);
         }
-        new ResolveScmStep(null, Collections.emptyList());
     }
 
 }

--- a/src/test/java/org/jenkinsci/plugins/workflow/multibranch/ResolveScmStepTest.java
+++ b/src/test/java/org/jenkinsci/plugins/workflow/multibranch/ResolveScmStepTest.java
@@ -26,6 +26,7 @@
 package org.jenkinsci.plugins.workflow.multibranch;
 
 import hudson.model.TopLevelItem;
+import java.util.Collections;
 import jenkins.scm.impl.mock.MockSCMController;
 import org.jenkinsci.plugins.workflow.cps.CpsFlowDefinition;
 import org.jenkinsci.plugins.workflow.job.WorkflowJob;
@@ -33,6 +34,10 @@ import org.junit.Before;
 import org.junit.ClassRule;
 import org.junit.Test;
 import org.jvnet.hudson.test.JenkinsRule;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
+import static org.junit.Assert.fail;
 
 public class ResolveScmStepTest {
 
@@ -121,4 +126,16 @@ public class ResolveScmStepTest {
             j.buildAndAssertSuccess(job);
         }
     }
+
+    @Test
+    public void constructorRejectsNullTargetsWithClearMessage() {
+        try {
+            new ResolveScmStep(null, null);
+            fail("expected NullPointerException");
+        } catch (NullPointerException e) {
+            assertThat(e.getMessage(), containsString("targets is required"));
+        }
+        new ResolveScmStep(null, Collections.emptyList());
+    }
+
 }


### PR DESCRIPTION
When `targets` is omitted from `resolveScm`, Pipeline DataBoundConstructor binding passes `null` and `new ArrayList<>(null)` throws a cryptic NPE (JENKINS-67005 / https://github.com/jenkinsci/github-branch-source-plugin/issues/1380).

Fail fast with a clear message that `targets` is required.

### Testing done

- Added unit test covering null `targets`
- Existing `ResolveScmStepTest` scenarios unchanged

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests that demonstrate the feature works or the issue is fixed

Made with [Cursor](https://cursor.com)